### PR TITLE
Add a link to discourse-based documentation on charmhub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ build/
 *.charm
 
 .coverage
+.tox
 __pycache__/
 *.py[cod]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: indico
 display-name: Indico
 summary: Indico web application.
-docs:
+docs: https://discourse.charmhub.io/t/indico-docs-index/6552
 maintainers:
   - launchpad.net/~canonical-is-devops
 description: |


### PR DESCRIPTION
Add a link to discourse-based documentation on charmhub.

Also, ignore files in the `.tox` directory.