### PR TITLE
Update dockerfile comments to reference upstream issue requiring python3.9

### DIFF
--- a/indico-nginx.Dockerfile
+++ b/indico-nginx.Dockerfile
@@ -2,8 +2,9 @@ FROM ubuntu:jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Python 3.9 is the only version supported by indico at the moment. Meaning it has to be installed from the PPA
-# deadsnakes/ppa
+# Python 3.9 is the only version supported by indico at the moment (see
+# https://github.com/indico/indico/issues/5364). Install from the PPA
+# deadsnakes/ppa until this is addressed.
 RUN apt update \
     && apt install -y software-properties-common \
     && add-apt-repository ppa:deadsnakes/ppa -y \

--- a/indico.Dockerfile
+++ b/indico.Dockerfile
@@ -2,8 +2,9 @@ FROM ubuntu:jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Python 3.9 is the only version supported by indico at the moment. Meaning it has to be installed from the PPA
-# deadsnakes/ppa
+# Python 3.9 is the only version supported by indico at the moment (see
+# https://github.com/indico/indico/issues/5364). Install from the PPA
+# deadsnakes/ppa until this is addressed.
 RUN apt update \
     && apt install -y software-properties-common \
     && add-apt-repository ppa:deadsnakes/ppa -y \


### PR DESCRIPTION
Link to the upstream issue referencing why indico requires python3.9. We expect them to support python3.10 in the next few months, at which point we can switch to the jammy-native python version.