### PR TITLE
Remove check-libs step from pull request workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,19 +7,6 @@ on:
         required: true
 
 jobs:
-  lib-check:
-    name: Check libraries
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@1.0.3
-        with:
-          credentials: "${{ secrets.charmhub-token }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -15,13 +15,24 @@ on:
       - track/**
 
 jobs:
-
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@1.0.3
+        with:
+          credentials: "${{ secrets.charmhub-token }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
   tests:
     name: Run Tests
     uses: ./.github/workflows/ci.yaml
     secrets:
       charmhub-token: "${{ secrets.CHARMHUB_TOKEN }}"
-
   publish-charm-to-edge:
     name: Publish Charm To Edge
     uses: ./.github/workflows/publish.yaml


### PR DESCRIPTION
The check-libs step requires a charmhub token to be configured in every forked repository. To avoid the need of manual set up, this step is removed from the pull request workflow.