### PR TITLE
Fix for #40, Recognizing existing relations on charm upgrade.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -430,4 +430,4 @@ class IndicoOperatorCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(IndicoOperatorCharm)
+    main(IndicoOperatorCharm, use_juju_for_storage=True)


### PR DESCRIPTION
To fix https://github.com/canonical/indico-operator/issues/40 a simple change has been made to workaround the StoredState issue. As stated on https://github.com/canonical/operator/issues/506 we can simply pass an extra argument to the main function to fix this.

For testing, we can just deploy our local charm as usual, following the deployment instructions. Then, we modify that charm with irrelevant changes and execute `charmcraft pack` again, then `juju refresh indico --path=./indico_ubuntu-20.04-amd64.charm`. You will see that now the existing relations are not missing and the charm is working as usual.