### PR TITLE
Add bootstrap page load integration test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,3 @@
 def pytest_addoption(parser):
     parser.addoption("--indico-image", action="store")
     parser.addoption("--indico-nginx-image", action="store")
-
-
-def pytest_generate_tests(metafunc):
-    if "indico_image" in metafunc.fixturenames:
-        metafunc.parametrize("indico_image", [metafunc.config.getoption("--indico-image")])
-    if "indico_nginx_image" in metafunc.fixturenames:
-        metafunc.parametrize(
-            "indico_nginx_image", [metafunc.config.getoption("--indico-nginx-image")]
-        )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,57 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+from pathlib import Path
+
+import pytest_asyncio
+import yaml
+from ops.model import WaitingStatus
+from pytest import Config, fixture
+from pytest_operator.plugin import OpsTest
+
+
+@fixture(scope="module")
+def metadata():
+    """Provides charm metadata."""
+    yield yaml.safe_load(Path("./metadata.yaml").read_text())
+
+
+@fixture(scope="module")
+def app_name(metadata):
+    """Provides app name from the metadata."""
+    yield metadata["name"]
+
+
+@pytest_asyncio.fixture(scope="module")
+async def indico_charm(ops_test: OpsTest, app_name: str, pytestconfig: Config):
+    """Indico charm used for integration testing.
+
+    Builds the charm and deploys it and the relations it depends on.
+    """
+    # Deploy relations to speed up overall execution
+    await asyncio.gather(
+        ops_test.model.deploy("postgresql-k8s"),
+        ops_test.model.deploy("redis-k8s", "redis-broker"),
+        ops_test.model.deploy("redis-k8s", "redis-cache"),
+    )
+
+    # Build and deploy the indico charm
+    charm = await ops_test.build_charm(".")
+    resources = {
+        "indico-image": pytestconfig.getoption("--indico-image"),
+        "indico-nginx-image": pytestconfig.getoption("--indico-nginx-image"),
+    }
+    await ops_test.model.deploy(charm, resources=resources, application_name=app_name)
+    await ops_test.model.wait_for_idle()
+
+    # Add required relations
+    assert ops_test.model.applications[app_name].units[0].workload_status == WaitingStatus.name
+    await asyncio.gather(
+        ops_test.model.add_relation(app_name, "postgresql-k8s:db"),
+        ops_test.model.add_relation(app_name, "redis-broker"),
+        ops_test.model.add_relation(app_name, "redis-cache"),
+    )
+    await ops_test.model.wait_for_idle(status="active")
+
+    yield charm

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -35,7 +35,6 @@ async def test_active(ops_test: OpsTest, app_name: str, indico_charm):
 
     Assume that the charm has already been built and is running.
     """
-    # build and deploy charm from local source folder
     assert ops_test.model.applications[app_name].units[0].workload_status == ActiveStatus.name
 
 
@@ -51,8 +50,9 @@ async def test_indico_is_up(ops_test: OpsTest, app_name: str, indico_charm):
     unit = list(status.applications[app_name].units)[0]
     address = status["applications"][app_name]["units"][unit]["address"]
 
-    # Send request to bootstrap page and set Host header to indico (which the application expects)
-    response = requests.get(f"http://{address}:8080/bootstrap", headers={"Host": "indico"})
+    # Send request to bootstrap page and set Host header to app_name (which the application
+    # expects)
+    response = requests.get(f"http://{address}:8080/bootstrap", headers={"Host": app_name})
     assert response.status_code == 200
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from ops.model import ActiveStatus, WaitingStatus
+from ops.model import ActiveStatus
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -27,42 +27,31 @@ async def juju_run(unit, cmd):
     return stdout
 
 
+@pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest, indico_image, indico_nginx_image):
-    """Build the charm-under-test and deploy it together with related charms.
+async def test_active(ops_test: OpsTest, app_name: str, indico_charm):
+    """Check that the charm is active.
 
-    Assert on the unit status before any relations/configurations take place.
+    Assume that the charm has already been built and is running.
     """
     # build and deploy charm from local source folder
-    charm = await ops_test.build_charm(".")
-    resources = {
-        "indico-image": indico_image,
-        "indico-nginx-image": indico_nginx_image,
-    }
-    await ops_test.model.deploy("postgresql-k8s")
-    await ops_test.model.deploy("redis-k8s", "redis-broker")
-    await ops_test.model.deploy("redis-k8s", "redis-cache")
-    await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME)
-    await ops_test.model.wait_for_idle()
-    assert ops_test.model.applications[APP_NAME].units[0].workload_status == WaitingStatus.name
-    await ops_test.model.add_relation(APP_NAME, "postgresql-k8s:db")
-    await ops_test.model.add_relation(APP_NAME, "redis-broker")
-    await ops_test.model.add_relation(APP_NAME, "redis-cache")
-    await ops_test.model.wait_for_idle(status="active")
-    assert ops_test.model.applications[APP_NAME].units[0].workload_status == ActiveStatus.name
+    assert ops_test.model.applications[app_name].units[0].workload_status == ActiveStatus.name
 
 
+@pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_health_checks(ops_test: OpsTest):
+async def test_health_checks(ops_test: OpsTest, indico_charm):
+    """Runs health checks for each container.
+
+    Assume that the charm has already been built and is running.
+    """
     container_list = ["indico", "indico-nginx", "indico-celery"]
     app = ops_test.model.applications["indico"]
     indico_unit = app.units[0]
     for container in container_list:
         result = await juju_run(
             indico_unit,
-            "PEBBLE_SOCKET=/charm/containers/{}/pebble.socket /charm/bin/pebble checks".format(
-                container
-            ),
+            f"PEBBLE_SOCKET=/charm/containers/{container}/pebble.socket /charm/bin/pebble checks",
         )
         # When executing the checks, `0/3` means there are 0 errors of 3.
         # Each check has it's own `0/3`, so we will count `n` times,

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins
@@ -71,6 +71,7 @@ deps =
     pytest
     juju
     pytest-operator
+    pytest-asyncio
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
- Fixes issue with the lint command where pflake8 is not compatible with flak8 version 5
- Moves the building of the charm, deploying the dependencies and creating the relations into a fixture
- Adds a tests that checks whether the indico bootstrap page loads