### PR TITLE
Add .dockerignore that only sends relevant files to the build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Ignore everything
+*
+
+# Include the files directory
+!files/*


### PR DESCRIPTION
Reduces the files that are sent to the build context by getting docker to ignore all files except for the `files` directory.