### PR TITLE
Pin charmcraft to version 1.x

### DIFF
--- a/.github/actions/build_oci_image/action.yaml
+++ b/.github/actions/build_oci_image/action.yaml
@@ -15,9 +15,6 @@ runs:
   steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-    - name: Install charmcraft
-      shell: bash
-      run: sudo snap install charmcraft --classic
     - name: Checkout
       uses: actions/checkout@v3
       with:

--- a/.github/actions/publish_oci_resource/action.yaml
+++ b/.github/actions/publish_oci_resource/action.yaml
@@ -15,7 +15,7 @@ runs:
   steps:
     - name: Install charmcraft
       shell: bash
-      run: sudo snap install charmcraft --classic
+      run: sudo snap install charmcraft --classic --channel=1.x/stable
     - name: Download all artifacts
       uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
Pin charmcraft version to 1.x to workaround the authentication issues experienced when uploading images to charmhub with version 2.0.0