### PR TITLE
Migrate to python 3.10

### DIFF
--- a/indico-nginx.Dockerfile
+++ b/indico-nginx.Dockerfile
@@ -11,8 +11,6 @@ FROM ubuntu:jammy
 RUN apt update \
     && apt install -y nginx
 
-RUN ls /usr/local/lib/
-
 COPY --from=0 /usr/local/lib/python3.10/dist-packages/indico/web/static /srv/indico/static
 COPY files/etc/nginx/nginx.conf /etc/nginx/nginx.conf
 

--- a/indico-nginx.Dockerfile
+++ b/indico-nginx.Dockerfile
@@ -2,22 +2,18 @@ FROM ubuntu:jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Python 3.9 is the only version supported by indico at the moment (see
-# https://github.com/indico/indico/issues/5364). Install from the PPA
-# deadsnakes/ppa until this is addressed.
 RUN apt update \
-    && apt install -y software-properties-common \
-    && add-apt-repository ppa:deadsnakes/ppa -y \
-    && apt update \
-    && apt install -y libpq-dev python3.9 python3.9-dev python3.9-distutils python3-pip \
-    && python3.9 -m pip install --prefer-binary indico indico-plugins
+    && apt install -y libpq-dev python3-pip \
+    && python3 -m pip install --prefer-binary indico indico-plugins
 
 FROM ubuntu:jammy
 
 RUN apt update \
     && apt install -y nginx
 
-COPY --from=0 /usr/local/lib/python3.9/dist-packages/indico/web/static /srv/indico/static
+RUN ls /usr/local/lib/
+
+COPY --from=0 /usr/local/lib/python3.10/dist-packages/indico/web/static /srv/indico/static
 COPY files/etc/nginx/nginx.conf /etc/nginx/nginx.conf
 
 ARG nginx_gid=2001

--- a/indico.Dockerfile
+++ b/indico.Dockerfile
@@ -2,15 +2,9 @@ FROM ubuntu:jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Python 3.9 is the only version supported by indico at the moment (see
-# https://github.com/indico/indico/issues/5364). Install from the PPA
-# deadsnakes/ppa until this is addressed.
 RUN apt update \
-    && apt install -y software-properties-common \
-    && add-apt-repository ppa:deadsnakes/ppa -y \
-    && apt update \
-    && apt install -y cron gettext git libpq-dev libxmlsec1-dev pkg-config postgresql-client python3.9 python3.9-dev python3.9-distutils python3-pip texlive-xetex \
-    && python3.9 -m pip install --prefer-binary indico indico-plugin-piwik python3-saml uwsgi \
+    && apt install -y cron gettext git libpq-dev libxmlsec1-dev pkg-config postgresql-client python3-pip texlive-xetex \
+    && pip install --prefer-binary indico indico-plugin-piwik python3-saml uwsgi \
     && /bin/bash -c "mkdir -p --mode=775 /srv/indico/{etc,tmp,log,cache,archive,custom}" \
     && /usr/local/bin/indico setup create-symlinks /srv/indico \
     && /usr/local/bin/indico setup create-logging-config /etc

--- a/src/charm.py
+++ b/src/charm.py
@@ -467,8 +467,7 @@ class IndicoOperatorCharm(CharmBase):
             for container_name in ["indico", "indico-celery"]:
                 indico_container = self.unit.get_container(container_name)
                 process = indico_container.exec(
-                    ["python3.9", "-m", "pip", "install"] + plugins,
-                    environment=self._get_http_proxy_configuration(),
+                    ["pip", "install"] + plugins, environment=self._get_http_proxy_configuration()
                 )
                 process.wait_output()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -216,8 +216,6 @@ class TestCharm(unittest.TestCase):
         )
         exec_mock.assert_any_call(
             [
-                "python3.9",
-                "-m",
                 "pip",
                 "install",
                 "git+https://example.git/#subdirectory=themes_cern",
@@ -292,13 +290,7 @@ class TestCharm(unittest.TestCase):
             environment=None,
         )
         exec_mock.assert_any_call(
-            [
-                "python3.9",
-                "-m",
-                "pip",
-                "install",
-                "git+https://example.git/#subdirectory=themes_cern",
-            ],
+            ["pip", "install", "git+https://example.git/#subdirectory=themes_cern"],
             environment=None,
         )
 
@@ -342,7 +334,7 @@ class TestCharm(unittest.TestCase):
         self.assertIsNotNone(secret_key)
         self.harness.set_leader(False)
         self.harness.set_leader(True)
-        self.assertEquals(
+        self.assertEqual(
             secret_key,
             self.harness.get_relation_data(rel_id, self.harness.charm.app.name).get("secret-key"),
         )


### PR DESCRIPTION
Migrate python to version 3.10, supported by the newly release Indico 3.2.