### PR TITLE
Fix site_url option validation (#77)

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -115,7 +115,7 @@ class IndicoOperatorCharm(CharmBase):
         site_url = self.config["site_url"]
         if site_url and not urlparse(site_url).hostname:
             return False, "Configuration option site_url is not valid"
-        return True, None
+        return True, ""
 
     def _get_external_hostname(self):
         """Extract and return hostname from site_url."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -267,6 +267,21 @@ class TestCharm(unittest.TestCase):
             "example.local", self.harness.charm.ingress.config_dict["service-hostname"]
         )
 
+    def test_config_changed_when_config_invalid(self):
+        self.set_up_all_relations()
+        self.harness.set_leader(True)
+
+        with patch.object(Container, "exec", return_value=MockExecProcess()):
+            self.harness.container_pebble_ready("nginx-prometheus-exporter")
+            self.harness.container_pebble_ready("indico")
+            self.harness.container_pebble_ready("indico-celery")
+            self.harness.container_pebble_ready("indico-nginx")
+        self.harness.update_config({"site_url": "example.local"})
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Configuration option site_url is not valid"),
+        )
+
     def test_config_changed_when_http_proxy_config_not_present(self):
         self.set_up_all_relations()
         self.harness.set_leader(True)
@@ -342,7 +357,7 @@ class TestCharm(unittest.TestCase):
         self.assertIsNotNone(secret_key)
         self.harness.set_leader(False)
         self.harness.set_leader(True)
-        self.assertEquals(
+        self.assertEqual(
             secret_key,
             self.harness.get_relation_data(rel_id, self.harness.charm.app.name).get("secret-key"),
         )


### PR DESCRIPTION
Validate that an actual hostname is provided to the nginx ingress integrator when the option is set.