### PR TITLE
Set http proxy env vars in indico containers

### DIFF
--- a/indico-nginx.Dockerfile
+++ b/indico-nginx.Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt update \
     && apt install -y libpq-dev python3-pip \
-    && python3 -m pip install --prefer-binary indico indico-plugins
+    && pip install --prefer-binary indico indico-plugins
 
 FROM ubuntu:jammy
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -410,6 +410,7 @@ class IndicoOperatorCharm(CharmBase):
                 }
             }
             env_config["INDICO_IDENTITY_PROVIDERS"] = str(identity_providers)
+            env_config = {**env_config, **self._get_http_proxy_configuration()}
         return env_config
 
     def _get_http_proxy_configuration(self):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -167,11 +167,11 @@ class TestCharm(unittest.TestCase):
                     "customization_debug": True,
                     "customization_sources_url": "https://example.com/custom",
                     "external_plugins": "git+https://example.git/#subdirectory=themes_cern",
+                    "http_proxy": "http://squid.internal:3128",
+                    "https_proxy": "https://squid.internal:3128",
                     "indico_support_email": "example@email.local",
                     "indico_public_support_email": "public@email.local",
                     "indico_no_reply_email": "noreply@email.local",
-                    "http_proxy": "http://squid.internal:3128",
-                    "https_proxy": "https://squid.internal:3128",
                     "saml_target_url": "https://login.ubuntu.com/saml/",
                     "site_url": "https://example.local:8080",
                     "smtp_server": "localhost",
@@ -187,6 +187,8 @@ class TestCharm(unittest.TestCase):
         updated_plan_env = updated_plan["services"]["indico"]["environment"]
 
         self.assertEqual("example.local", updated_plan_env["SERVICE_HOSTNAME"])
+        self.assertEqual("http://squid.internal:3128", updated_plan_env["HTTP_PROXY"])
+        self.assertEqual("https://squid.internal:3128", updated_plan_env["HTTPS_PROXY"])
         self.assertEqual("example@email.local", updated_plan_env["INDICO_SUPPORT_EMAIL"])
         self.assertEqual("public@email.local", updated_plan_env["INDICO_PUBLIC_SUPPORT_EMAIL"])
         self.assertEqual("noreply@email.local", updated_plan_env["INDICO_NO_REPLY_EMAIL"])
@@ -231,6 +233,8 @@ class TestCharm(unittest.TestCase):
         updated_plan_env = updated_plan["services"]["indico-celery"]["environment"]
 
         self.assertEqual("example.local", updated_plan_env["SERVICE_HOSTNAME"])
+        self.assertEqual("http://squid.internal:3128", updated_plan_env["HTTP_PROXY"])
+        self.assertEqual("https://squid.internal:3128", updated_plan_env["HTTPS_PROXY"])
         self.assertEqual("example@email.local", updated_plan_env["INDICO_SUPPORT_EMAIL"])
         self.assertEqual("public@email.local", updated_plan_env["INDICO_PUBLIC_SUPPORT_EMAIL"])
         self.assertEqual("noreply@email.local", updated_plan_env["INDICO_NO_REPLY_EMAIL"])


### PR DESCRIPTION
Set http proxy env vars in indico containers to prevent timeouts when accessing external resources from the application
