### PR TITLE
Define coverage threshold in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@
 branch = true
 
 [tool.coverage.report]
+fail_under = 90
 show_missing = true
+
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ deps =
 commands =
     coverage run --source={[vars]src_path} \
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
-    coverage report --fail-under=90
+    coverage report
 
 [testenv:integration]
 description = Run integration tests


### PR DESCRIPTION
Define coverage threshold in pyproject.toml file as per [IS contributing charm guide](https://github.com/canonical/is-charms-contributing-guide)