### PR TITLE
Export images in docker format

### DIFF
--- a/.github/actions/build_oci_image/action.yaml
+++ b/.github/actions/build_oci_image/action.yaml
@@ -25,7 +25,7 @@ runs:
       with:
         tags: ${{ inputs.tags }}
         file: ${{ inputs.dockerfile }}
-        outputs: type=oci,dest=/tmp/${{ inputs.resource-name }}.tar
+        outputs: type=docker,dest=/tmp/${{ inputs.resource-name }}.tar
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Docker image format is built faster and the current pipeline import/export and upload steps support it.