### PR TITLE
Bump our coverage 'fail under' value to 91 to ensure we don't regress from current coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 branch = true
 
 [tool.coverage.report]
-fail_under = 90
+fail_under = 91
 show_missing = true
 
 


### PR DESCRIPTION
Trivial change to bump coverage 'fail under' to 91%.