### PR TITLE
Increase celery readiness check period

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -261,8 +261,8 @@ class IndicoOperatorCharm(CharmBase):
                 "ready": {
                     "override": "replace",
                     "level": "alive",
-                    "period": "20s",
-                    "timeout": "19s",
+                    "period": "120s",
+                    "timeout": "119s",
                     "exec": {
                         "command": "/usr/local/bin/indico celery inspect ping",
                         "environment": indico_env_config,


### PR DESCRIPTION
Increase celery readiness check period and timeout to mitigate the effect of existing blocking tasks when checking the status.