### PR TITLE
Enable indico user

### DIFF
--- a/indico.Dockerfile
+++ b/indico.Dockerfile
@@ -26,7 +26,7 @@ ARG indico_gid=2000
 ARG indico_uid=2000
 
 RUN addgroup --gid ${indico_gid} indico \
-    && adduser --system --gid ${indico_gid} --uid ${indico_uid} --home /srv/indico --disabled-login indico \
+    && adduser --system --gid ${indico_gid} --uid ${indico_uid} --home /srv/indico indico \
     &&  echo "* * * * * git -C /srv/indico/custom pull" | crontab -u indico - \
     && /etc/init.d/cron start
 


### PR DESCRIPTION
The crontab of the user "indico" won't run if disabled. This PR enables it.