### PR TITLE
Unpin flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8==4.0.1
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
Pinning flak8 to version 4.0.1 is not needed anymore.