### PR TITLE
ci(static): Add static code tests

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,4 +1,4 @@
-assert_used:
-  skips: ["*/*test.py", "*/test_*.py"]
-exclude_dirs:
-  - '/venv/'
+# FILE: .bandit
+[bandit]
+exclude = venv
+skips = B101

--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,4 @@
+assert_used:
+  skips: ["*/*test.py", "*/test_*.py"]
+exclude_dirs:
+  - '/venv/'

--- a/.bandit
+++ b/.bandit
@@ -1,4 +1,4 @@
-# FILE: .bandit
-[bandit]
-exclude = venv
-skips = B101
+assert_used:
+  skips: ["*/*test.py", "*/test_*.py"]
+exclude_dirs:
+  - '/venv/'

--- a/.github/files/comment_pr.js
+++ b/.github/files/comment_pr.js
@@ -40,5 +40,5 @@ module.exports = async ({github, context}) => {
         const unitReport = report.reports.unit.output.trim();
         await createComment(`Unit tests failed for ${sha}\n\`\`\`\n${unitReport}\n\`\`\``);
     }
-    await createComment(`Test coverage report for ${sha}\n\`\`\`\n${coverageReport}\n\`\`\`\n\`\`\`\n${staticReport}\n\`\`\``);
+    await createComment(`Test coverage report for ${sha}\n\`\`\`\n${coverageReport}\n\`\`\`\n\`\`\`\nstatic report\n${staticReport}\nreport end\`\`\``);
 }

--- a/.github/files/comment_pr.js
+++ b/.github/files/comment_pr.js
@@ -31,8 +31,6 @@ module.exports = async ({github, context}) => {
 
     const coverageReport = report.reports.coverage.output.trim()
     const staticReport = report.reports["static"].output.trim()
-    console.log(`coverage report ${coverageReport}`)
-    console.log(`static report ${staticReport}`)
     await deleteGithubActionsComments();
     if (!report.reports.lint.success) {
         const lintReport = report.reports.lint.output.trim();
@@ -42,5 +40,5 @@ module.exports = async ({github, context}) => {
         const unitReport = report.reports.unit.output.trim();
         await createComment(`Unit tests failed for ${sha}\n\`\`\`\n${unitReport}\n\`\`\``);
     }
-    await createComment(`Test coverage report for ${sha}\n\`\`\`\n${coverageReport}\n\`\`\`\n\`\`\`\nstatic report\n${staticReport}\nreport end\`\`\``);
+    await createComment(`Test coverage report for ${sha}\n\`\`\`\n${coverageReport}\n\`\`\`\nStatic code analysis report\n\`\`\`\n${staticReport}\n\`\`\``);
 }

--- a/.github/files/comment_pr.js
+++ b/.github/files/comment_pr.js
@@ -31,6 +31,8 @@ module.exports = async ({github, context}) => {
 
     const coverageReport = report.reports.coverage.output.trim()
     const staticReport = report.reports["static"].output.trim()
+    console.log(`coverage report ${coverageReport}`)
+    console.log(`static report ${staticReport}`)
     await deleteGithubActionsComments();
     if (!report.reports.lint.success) {
         const lintReport = report.reports.lint.output.trim();

--- a/.github/files/comment_pr.js
+++ b/.github/files/comment_pr.js
@@ -30,7 +30,7 @@ module.exports = async ({github, context}) => {
     }
 
     const coverageReport = report.reports.coverage.output.trim()
-    const staticReport = report.reports.static.output.trim()
+    const staticReport = report.reports["static"].output.trim()
     await deleteGithubActionsComments();
     if (!report.reports.lint.success) {
         const lintReport = report.reports.lint.output.trim();

--- a/.github/files/comment_pr.js
+++ b/.github/files/comment_pr.js
@@ -30,6 +30,7 @@ module.exports = async ({github, context}) => {
     }
 
     const coverageReport = report.reports.coverage.output.trim()
+    const staticReport = report.reports.static.output.trim()
     await deleteGithubActionsComments();
     if (!report.reports.lint.success) {
         const lintReport = report.reports.lint.output.trim();
@@ -39,5 +40,5 @@ module.exports = async ({github, context}) => {
         const unitReport = report.reports.unit.output.trim();
         await createComment(`Unit tests failed for ${sha}\n\`\`\`\n${unitReport}\n\`\`\``);
     }
-    await createComment(`Test coverage report for ${sha}\n\`\`\`\n${coverageReport}\n\`\`\``);
+    await createComment(`Test coverage report for ${sha}\n\`\`\`\n${coverageReport}\n\`\`\`\n\`\`\`\n${staticReport}\n\`\`\``);
 }

--- a/.github/files/comment_pr.js
+++ b/.github/files/comment_pr.js
@@ -40,5 +40,14 @@ module.exports = async ({github, context}) => {
         const unitReport = report.reports.unit.output.trim();
         await createComment(`Unit tests failed for ${sha}\n\`\`\`\n${unitReport}\n\`\`\``);
     }
-    await createComment(`Test coverage report for ${sha}\n\`\`\`\n${coverageReport}\n\`\`\`\nStatic code analysis report\n\`\`\`\n${staticReport}\n\`\`\``);
+    await createComment(
+`Test coverage report for ${sha}
+\`\`\`
+${coverageReport}
+\`\`\`
+Static code analysis report
+\`\`\`
+${staticReport}
+\`\`\``
+    );
 }

--- a/.github/files/extract_test_result.py
+++ b/.github/files/extract_test_result.py
@@ -20,12 +20,16 @@ with open("./test-result.json", encoding="utf-8") as f:
     unit_result = result["testenvs"]["unit"]["test"]
     unit_success = unit_result[0]["retcode"] == 0
     unit_output = unit_result[0]["output"]
+    static_result = result["testenvs"]["static"]["test"]
+    static_success = static_result[0]["retcode"] == 0
+    static_output = static_result[0]["output"]
     coverage_result = result["testenvs"]["coverage-report"]["test"]
     coverage_success = coverage_result[0]["retcode"] == 0
     coverage_output = coverage_result[0]["output"]
     reports = {
         "lint": {"success": lint_success, "output": no_color(lint_output)},
         "unit": {"success": unit_success, "output": no_color(unit_output)},
+        "static": {"success": static_success, "output": no_color(static_output)},
         "coverage": {"success": coverage_success, "output": no_color(coverage_output)}
     }
     final_report = {

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run tests
-        run: tox -e lint,unit,coverage-report --result-json=test-result.json
+        run: tox -e lint,unit,static,coverage-report --result-json=test-result.json
       - name: Export test report
         if: always() && github.event_name == 'pull_request'
         id: export-test-report

--- a/tox.ini
+++ b/tox.ini
@@ -91,4 +91,4 @@ deps =
     bandit
     -r{toxinidir}/requirements.txt
 commands =
-    bandit -x {toxinidir}/venv -s B101 -r {[vars]src_path} {[vars]tst_path}
+    bandit -c {toxinidir}/.bandit -r {[vars]src_path} {[vars]tst_path}

--- a/tox.ini
+++ b/tox.ini
@@ -84,3 +84,11 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+
+[testenv:static]
+description = Run static analysis tests
+deps =
+    bandit
+    -r{toxinidir}/requirements.txt
+commands =
+    bandit -x {toxinidir}/venv -s B101 -r {[vars]src_path} {[vars]tst_path}


### PR DESCRIPTION
This PR implements bandit as a static code analysis tool.

The scan includes src/ and tests/ directories, scanned recursively. Third party code (like venv/ and lib/) is not scanned currently.

The `assert_used` test (B101) is not enabled, it is noisy on test files and is also not a security or other type of concern.

The output is made part of the report for lint and unit tests.

Note I've preserved the workflow step to be `lint-and-unit-test` for now, suggestions are welcome on whether I should change it to reflect it includes static code analysis explicitly or it is fine as is.