### PR TITLE
Unpin flake8 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ line-length = 99
 target-version = ["py38"]
 
 [tool.isort]
+line_length = 99
 profile = "black"
 
 # Linting tools configuration

--- a/src/charm.py
+++ b/src/charm.py
@@ -271,7 +271,10 @@ class IndicoOperatorCharm(CharmBase):
                 "exporter": {
                     "override": "replace",
                     "summary": "Exporter",
-                    "command": "nginx-prometheus-exporter -nginx.scrape-uri=http://localhost:9080/stub_status",
+                    "command": (
+                        "nginx-prometheus-exporter"
+                        " -nginx.scrape-uri=http://localhost:9080/stub_status"
+                    ),
                     "startup": "enabled",
                 },
             },
@@ -356,7 +359,21 @@ class IndicoOperatorCharm(CharmBase):
                         "url": "https://login.ubuntu.com/+logout",
                         "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
                     },
-                    "x509cert": "MIICjzCCAfigAwIBAgIJALNN/vxaR1hyMA0GCSqGSIb3DQEBBQUAMDoxCzAJBgNVBAYTAkdCMRMwEQYDVQQIEwpTb21lLVN0YXRlMRYwFAYDVQQKEw1DYW5vbmljYWwgTHRkMB4XDTEyMDgxMDEyNDE0OFoXDTEzMDgxMDEyNDE0OFowOjELMAkGA1UEBhMCR0IxEzARBgNVBAgTClNvbWUtU3RhdGUxFjAUBgNVBAoTDUNhbm9uaWNhbCBMdGQwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMM4pmIxkv419q8zj5EojK57y6plU/+k3apX6w1PgAYeI0zhNuud/tiqKVQEDyZ6W7HNeGtWSh5rewy8c07BShcHG5Y8ibzBdIibGs5k6gvtmsRiXDE/F39+RrPSW18beHhEuoVJM9RANp3MYMOK11SiClSiGo+NfBKFuoqNX3UjAgMBAAGjgZwwgZkwHQYDVR0OBBYEFH/no88pbywRnW6Fz+B4lQ04w/86MGoGA1UdIwRjMGGAFH/no88pbywRnW6Fz+B4lQ04w/86oT6kPDA6MQswCQYDVQQGEwJHQjETMBEGA1UECBMKU29tZS1TdGF0ZTEWMBQGA1UEChMNQ2Fub25pY2FsIEx0ZIIJALNN/vxaR1hyMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEArTGbZ1rg++aBxnNuJ7eho62JKKtRW5O+kMBvBLWi7fKck5uXDE6d7Jv6hUy/gwUZV7r5kuPwRlw3Pu6AX4R60UsQuVG1/VVVI7nu32iCkXx5Vzq446IkVRdk/QOda1dRyq0oaifUUhJfwVFSsm95ENDFdGqD0raj7g77ajcBMf8=",
+                    "x509cert": (
+                        "MIICjzCCAfigAwIBAgIJALNN/vxaR1hyMA0GCSqGSIb3DQEBBQUAMDoxCzAJBgNVBAYTAkdCM"
+                        "RMwEQYDVQQIEwpTb21lLVN0YXRlMRYwFAYDVQQKEw1DYW5vbmljYWwgTHRkMB4XDTEyMDgxMD"
+                        "EyNDE0OFoXDTEzMDgxMDEyNDE0OFowOjELMAkGA1UEBhMCR0IxEzARBgNVBAgTClNvbWUtU3R"
+                        "hdGUxFjAUBgNVBAoTDUNhbm9uaWNhbCBMdGQwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB"
+                        "AMM4pmIxkv419q8zj5EojK57y6plU/+k3apX6w1PgAYeI0zhNuud/tiqKVQEDyZ6W7HNeGtWS"
+                        "h5rewy8c07BShcHG5Y8ibzBdIibGs5k6gvtmsRiXDE/F39+RrPSW18beHhEuoVJM9RANp3MYM"
+                        "OK11SiClSiGo+NfBKFuoqNX3UjAgMBAAGjgZwwgZkwHQYDVR0OBBYEFH/no88pbywRnW6Fz+B"
+                        "4lQ04w/86MGoGA1UdIwRjMGGAFH/no88pbywRnW6Fz+B4lQ04w/86oT6kPDA6MQswCQYDVQQG"
+                        "EwJHQjETMBEGA1UECBMKU29tZS1TdGF0ZTEWMBQGA1UEChMNQ2Fub25pY2FsIEx0ZIIJALNN/"
+                        "vxaR1hyMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEArTGbZ1rg++aBxnNuJ7eho6"
+                        "2JKKtRW5O+kMBvBLWi7fKck5uXDE6d7Jv6hUy/gwUZV7r5kuPwRlw3Pu6AX4R60UsQuVG1/VV"
+                        "VI7nu32iCkXx5Vzq446IkVRdk/QOda1dRyq0oaifUUhJfwVFSsm95ENDFdGqD0raj7g77ajcB"
+                        "Mf8="
+                    ),
                 },
             }
             auth_providers = {"ubuntu": {"type": "saml", "saml_config": saml_config}}

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -182,7 +182,7 @@ class TestCharm(unittest.TestCase):
                     "smtp_login": "user",
                     "smtp_password": "pass",
                     "smtp_use_tls": False,
-                    "s3_storage": "s3:bucket=my-indico-test-bucket,access_key=12345,secret_key=topsecret",
+                    "s3_storage": "s3:bucket=test-bucket,access_key=12345,secret_key=topsecret",
                 }
             )
 
@@ -208,7 +208,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual("s3", updated_plan_env["ATTACHMENT_STORAGE"])
         self.assertEqual("fs:/srv/indico/archive", storage_dict["default"])
         self.assertEqual(
-            "s3:bucket=my-indico-test-bucket,access_key=12345,secret_key=topsecret",
+            "s3:bucket=test-bucket,access_key=12345,secret_key=topsecret",
             storage_dict["s3"],
         )
         exec_mock.assert_any_call(
@@ -251,7 +251,7 @@ class TestCharm(unittest.TestCase):
         storage_dict = literal_eval(updated_plan_env["STORAGE_DICT"])
         self.assertEqual("fs:/srv/indico/archive", storage_dict["default"])
         self.assertEqual(
-            "s3:bucket=my-indico-test-bucket,access_key=12345,secret_key=topsecret",
+            "s3:bucket=test-bucket,access_key=12345,secret_key=topsecret",
             storage_dict["s3"],
         )
         auth_providers = literal_eval(updated_plan_env["INDICO_AUTH_PROVIDERS"])
@@ -327,11 +327,10 @@ class TestCharm(unittest.TestCase):
 
         self.harness.update_config({"saml_target_url": "sample.com/saml"})
         self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus(
-                "Invalid saml_target_url option provided. Only https://login.ubuntu.com/saml/ is available."
-            ),
+            self.harness.model.unit.status.name,
+            BlockedStatus.name,
         )
+        self.assertTrue("Invalid saml_target_url option" in self.harness.model.unit.status.message)
 
     def test_pebble_ready_when_relations_not_ready(self):
         self.harness.container_pebble_ready("indico")

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8==4.0.1
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
Pinning flake8 to version 4.0.1 is not needed anymore. The compatibility issues have been resolved.