### PR TITLE
Access redis relation data directly

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -296,14 +296,18 @@ class IndicoOperatorCharm(CharmBase):
         cache_rel = next(
             rel for rel in self.model.relations["redis"] if rel.app.name.startswith("redis-cache")
         )
-        cache_host = self._stored.redis_relation[cache_rel.id]["hostname"]
-        cache_port = self._stored.redis_relation[cache_rel.id]["port"]
+        cache_unit = next(unit for unit in cache_rel.data if unit.name.startswith("redis-cache"))
+        cache_host = cache_rel.data[cache_unit].get("hostname")
+        cache_port = cache_rel.data[cache_unit].get("port")
 
         broker_rel = next(
             rel for rel in self.model.relations["redis"] if rel.app.name.startswith("redis-broker")
         )
-        broker_host = self._stored.redis_relation[broker_rel.id]["hostname"]
-        broker_port = self._stored.redis_relation[broker_rel.id]["port"]
+        broker_unit = next(
+            unit for unit in broker_rel.data if unit.name.startswith("redis-broker")
+        )
+        broker_host = broker_rel.data[broker_unit].get("hostname")
+        broker_port = broker_rel.data[broker_unit].get("port")
 
         available_plugins = []
         process = container.exec(["indico", "setup", "list-plugins"])

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -426,14 +426,21 @@ class TestCharm(unittest.TestCase):
 
     def set_up_all_relations(self):
         self.harness.charm._stored.db_uri = "db-uri"
-        self.harness.add_relation("indico-peers", self.harness.charm.app.name)
-        broker_relation_id = self.harness.add_relation("redis", self.harness.charm.app.name)
-        self.harness.add_relation_unit(broker_relation_id, "redis-broker/0")
-        cache_relation_id = self.harness.add_relation("redis", self.harness.charm.app.name)
-        self.harness.add_relation_unit(cache_relation_id, "redis-cache/0")
         self.db_relation_id = self.harness.add_relation("db", self.harness.charm.app.name)
         self.harness.add_relation_unit(self.db_relation_id, "postgresql/0")
-        self.harness.charm._stored.redis_relation = {
-            broker_relation_id: {"hostname": "broker-host", "port": 1010},
-            cache_relation_id: {"hostname": "cache-host", "port": 1011},
-        }
+
+        self.harness.add_relation("indico-peers", self.harness.charm.app.name)
+
+        broker_relation_id = self.harness.add_relation("redis", self.harness.charm.app.name)
+        self.harness.add_relation_unit(broker_relation_id, "redis-broker/0")
+
+        cache_relation_id = self.harness.add_relation("redis", self.harness.charm.app.name)
+        self.harness.add_relation_unit(cache_relation_id, "redis-cache/0")
+
+        cache_relation = self.harness.model.get_relation("redis", cache_relation_id)
+        cache_unit = self.harness.model.get_unit("redis-cache/0")
+        cache_relation.data = {cache_unit: {"hostname": "cache-host", "port": 1011}}
+
+        broker_relation = self.harness.model.get_relation("redis", broker_relation_id)
+        broker_unit = self.harness.model.get_unit("redis-broker/0")
+        broker_relation.data = {broker_unit: {"hostname": "broker-host", "port": 1010}}


### PR DESCRIPTION
Access redis relation data directly from the relation instead of using the provided stored stated to prevent errors when the stored state has not been updated due to the delay when triggering the `redis_relation_changed` event.