### PR TITLE
Configure bandit in pyproject.toml instead of using .bandit file

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,4 +1,0 @@
-assert_used:
-  skips: ["*/*test.py", "*/test_*.py"]
-exclude_dirs:
-  - '/venv/'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,11 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+[tool.bandit]
+exclude_dirs = ["/venv/"]
+[tool.bandit.assert_used]
+skips = ["*/*test.py", "*/test_*.py"]
+
 # Testing tools configuration
 [tool.coverage.run]
 branch = true

--- a/tox.ini
+++ b/tox.ini
@@ -89,6 +89,7 @@ commands =
 description = Run static analysis tests
 deps =
     bandit
+    toml
     -r{toxinidir}/requirements.txt
 commands =
-    bandit -c {toxinidir}/.bandit -r {[vars]src_path} {[vars]tst_path}
+    bandit -c {toxinidir}/pyproject.toml -r {[vars]src_path} {[vars]tst_path}


### PR DESCRIPTION
Closes #141 