### PR TITLE
hotfix(ops): Pin Ops lib to 1.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-ops == 1.5.2
+# see https://github.com/canonical/operator/pull/786 
+ops == 1.5.2 # >= 1.5.3 raises an error, potentially we are using the tests wrong
 ops-lib-pgsql

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ops >= 1.4.0
+ops == 1.5.2
 ops-lib-pgsql


### PR DESCRIPTION
Ops library at 1.5.3 is broken and causing our unit tests to fail. Until that is fixed, the library is pinned to the previous version under which the tests behave as expected (passing/failing where they should).