### PR TITLE
Fix prometheus metrics scrape

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -71,7 +71,7 @@ class IndicoOperatorCharm(CharmBase):
         self.framework.observe(self.on.redis_relation_changed, self._on_config_changed)
         self.ingress = IngressRequires(self, self._make_ingress_config())
         self._metrics_endpoint = MetricsEndpointProvider(
-            self, jobs=[{"static_configs": [{"targets": ["localhost:9113", "localhost:9102"]}]}]
+            self, jobs=[{"static_configs": [{"targets": ["*:9113", "*:9102"]}]}]
         )
         self._grafana_dashboards = GrafanaDashboardProvider(self)
 

--- a/src/grafana_dashboards/indico.json
+++ b/src/grafana_dashboards/indico.json
@@ -146,8 +146,6 @@
                     "to": "null"
                 }
             ],
-            "repeat": "juju_unit",
-            "repeatDirection": "h",
             "sparkline": {
                 "fillColor": "rgba(31, 118, 189, 0.18)",
                 "full": false,


### PR DESCRIPTION
Fix prometheus metrics scrape. `localhost` is not working as hostname for the targets #153 
Remove repeated panel as it is incompatible with the injected filters