### PR TITLE
Fix failing unit tests with ops 1.5.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-# see https://github.com/canonical/operator/pull/786 
-ops == 1.5.2 # >= 1.5.3 raises an error, potentially we are using the tests wrong
+ops
 ops-lib-pgsql

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -30,7 +30,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for redis-broker relation")
         )
-        redis_relation_id = self.harness.add_relation("redis", self.harness.charm.app.name)
+        redis_relation_id = self.harness.add_relation("redis", "redis-broker")
         self.harness.add_relation_unit(redis_relation_id, "redis-broker/0")
         self.harness.update_relation_data(
             redis_relation_id, "redis-broker/0", {"something": "just to trigger rel-changed event"}
@@ -38,7 +38,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for redis-cache relation")
         )
-        redis_relation_id = self.harness.add_relation("redis", self.harness.charm.app.name)
+        redis_relation_id = self.harness.add_relation("redis", "redis-cache")
         self.harness.add_relation_unit(redis_relation_id, "redis-cache/0")
         self.harness.update_relation_data(
             redis_relation_id, "redis-cache/0", {"something": "just to trigger rel-changed event"}
@@ -426,15 +426,15 @@ class TestCharm(unittest.TestCase):
 
     def set_up_all_relations(self):
         self.harness.charm._stored.db_uri = "db-uri"
-        self.db_relation_id = self.harness.add_relation("db", self.harness.charm.app.name)
+        self.db_relation_id = self.harness.add_relation("db", "postgresql")
         self.harness.add_relation_unit(self.db_relation_id, "postgresql/0")
 
         self.harness.add_relation("indico-peers", self.harness.charm.app.name)
 
-        broker_relation_id = self.harness.add_relation("redis", self.harness.charm.app.name)
+        broker_relation_id = self.harness.add_relation("redis", "redis-broker")
         self.harness.add_relation_unit(broker_relation_id, "redis-broker/0")
 
-        cache_relation_id = self.harness.add_relation("redis", self.harness.charm.app.name)
+        cache_relation_id = self.harness.add_relation("redis", "redis-cache")
         self.harness.add_relation_unit(cache_relation_id, "redis-cache/0")
 
         cache_relation = self.harness.model.get_relation("redis", cache_relation_id)


### PR DESCRIPTION
Due to a bad usage of "add_relation" method of Harness, the unit tests started to fail with ops 1.5.3 (which is more strict in validating data relations, see https://github.com/canonical/operator/pull/786)