### PR TITLE
Run integration tests after unit tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -2,6 +2,10 @@ name: Integration tests
 
 on:
   pull_request:
+  workflow_run:
+    workflows: ["Tests"]
+    types:
+      - completed
 
 jobs:
   integration-tests:


### PR DESCRIPTION
Trigger integration test also after unit test execution. Will be kept only if the docker registry can be accessed from a PR from a fork.