### PR TITLE
ISD-189 indico chaos engineering

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -118,7 +118,7 @@ jobs:
           EXPERIMENT_NAME: pod-delete
 
       - name: Run chaos mesh pod kill action
-        uses: chaos-mesh/chaos-mesh-action@v0.5
+        uses: chaos-mesh/chaos-mesh-action@master
         env:
           CHAOS_MESH_VERSION: v2.4.1
           CFG_BASE64: YXBpVmVyc2lvbjogY2hhb3MtbWVzaC5vcmcvdjFhbHBoYTEKa2luZDogUG9kQ2hhb3MKbWV0YWRhdGE6CiAgbmFtZTogcG9kLWtpbGwtZXhhbXBsZQogIG5hbWVzcGFjZTogY2hhb3MtbWVzaApzcGVjOgogIGFjdGlvbjogcG9kLWtpbGwKICBtb2RlOiBvbmUKICBzZWxlY3RvcjoKICAgIG5hbWVzcGFjZXM6CiAgICAgIC0gdGVzdGluZwogICAgbGFiZWxTZWxlY3RvcnM6CiAgICAgICdhcHAua3ViZXJuZXRlcy5pby9uYW1lJzogJ2luZGljbycK

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -131,9 +131,3 @@ jobs:
         uses: merkata/github-chaos-actions@master
         env:
           EXPERIMENT_NAME: disk-fill
-
-      - name: Uninstall Litmus
-        if: always()
-        uses: merkata/github-chaos-actions@master
-        env:
-          LITMUS_CLEANUP: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -98,6 +98,8 @@ jobs:
         uses: litmuschaos/github-chaos-actions@master
         env:
           INSTALL_LITMUS: true
+          CHAOS_NAMESPACE: testing
+          APP_NS: testing
 
       - name: Running Litmus pod delete chaos experiment
         uses: litmuschaos/github-chaos-actions@master

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -90,7 +90,7 @@ jobs:
           model: testing
 
       - name: Setting up kubeconfig ENV for Github Chaos Action
-        run: echo ::set-env name=KUBE_CONFIG_DATA::$(microk8s config | base64 -w 0)
+        run: echo ::set-env name=KUBE_CONFIG_DATA::$(sudo microk8s config | base64 -w 0)
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,6 +7,9 @@ on:
       images:
         description: Pushed docker images
         value: ${{ jobs.get-images.outputs.images }}
+  push:
+    branches:
+      - 'ISD-189-indico-chaos-engineering'
 
 env:
   REGISTRY: ghcr.io
@@ -70,6 +73,7 @@ jobs:
           password = \"${{ secrets.GITHUB_TOKEN }}\"
           " >> /var/snap/microk8s/current/args/containerd-template.toml'
           sudo su -c 'systemctl restart snap.microk8s.daemon-containerd.service && microk8s status --wait-ready'
+
       - name: Run integration tests
         run: |
           echo "CHARM_NAME=$(yq '.name' metadata.yaml)" >> $GITHUB_ENV
@@ -77,10 +81,41 @@ jobs:
           for image_name in $(echo '${{ needs.get-images.outputs.images }}' | jq -cr '.[]'); do
             args="${args} --${image_name}-image ${{ env.REGISTRY }}/${{ env.OWNER }}/${image_name}:${{ github.run_id }}"
           done
-          tox -e integration -- --model testing $args
+          tox -e integration -- --model testing --keep-models $args
       - name: Dump logs
         uses: canonical/charm-logdump-action@main
         if: failure()
         with:
           app: ${{ env.CHARM_NAME }}
           model: testing
+
+      - name: Setting up kubeconfig ENV for Github Chaos Action
+        run: echo ::set-env name=KUBE_CONFIG_DATA::$(microk8s config | base64 -w 0)
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
+      - name: Setup Litmus
+        uses: litmuschaos/github-chaos-actions@master
+        env:
+          INSTALL_LITMUS: true
+
+      - name: Running Litmus pod delete chaos experiment
+        uses: litmuschaos/github-chaos-actions@master
+        env:
+          EXPERIMENT_NAME: pod-delete
+          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE_TAG: latest
+          JOB_CLEANUP_POLICY: delete
+          APP_NS: testing
+          APP_LABEL: app.kubernetes.io/name=indico
+          APP_KIND: statefulset
+          IMAGE_PULL_POLICY: Always
+          TOTAL_CHAOS_DURATION: 30
+          CHAOS_INTERVAL: 10
+          FORCE: false
+
+      - name: Uninstall Litmus
+        if: always()
+        uses: litmuschaos/github-chaos-actions@master
+        env:
+          LITMUS_CLEANUP: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -116,18 +116,3 @@ jobs:
         uses: merkata/github-chaos-actions@master
         env:
           EXPERIMENT_NAME: pod-delete
-
-      - name: Running Litmus pod cpu hog chaos experiment
-        uses: merkata/github-chaos-actions@master
-        env:
-          EXPERIMENT_NAME: pod-cpu-hog
-
-      - name: Running Litmus pod memory hog chaos experiment
-        uses: merkata/github-chaos-actions@master
-        env:
-          EXPERIMENT_NAME: pod-memory-hog
-
-      - name: Running Litmus disk fill chaos experiment
-        uses: merkata/github-chaos-actions@master
-        env:
-          EXPERIMENT_NAME: disk-fill

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -106,6 +106,7 @@ jobs:
           EXPERIMENT_IMAGE: litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: latest
           JOB_CLEANUP_POLICY: delete
+          CHAOS_NAMESPACE: testing
           APP_NS: testing
           APP_LABEL: app.kubernetes.io/name=indico
           APP_KIND: statefulset

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -121,4 +121,4 @@ jobs:
         uses: chaos-mesh/chaos-mesh-action@master
         env:
           CHAOS_MESH_VERSION: v2.4.1
-          CFG_BASE64: YXBpVmVyc2lvbjogY2hhb3MtbWVzaC5vcmcvdjFhbHBoYTEKa2luZDogUG9kQ2hhb3MKbWV0YWRhdGE6CiAgbmFtZTogcG9kLWtpbGwtZXhhbXBsZQogIG5hbWVzcGFjZTogY2hhb3MtbWVzaApzcGVjOgogIGFjdGlvbjogcG9kLWtpbGwKICBtb2RlOiBvbmUKICBzZWxlY3RvcjoKICAgIG5hbWVzcGFjZXM6CiAgICAgIC0gdGVzdGluZwogICAgbGFiZWxTZWxlY3RvcnM6CiAgICAgICdhcHAua3ViZXJuZXRlcy5pby9uYW1lJzogJ2luZGljbycK
+          CFG_BASE64: YXBpVmVyc2lvbjogY2hhb3MtbWVzaC5vcmcvdjFhbHBoYTEKa2luZDogUG9kQ2hhb3MKbWV0YWRhdGE6CiAgbmFtZTogcG9kLWtpbGwtZXhhbXBsZQogIG5hbWVzcGFjZTogdGVzdGluZwpzcGVjOgogIGFjdGlvbjogcG9kLWtpbGwKICBtb2RlOiBvbmUKICBzZWxlY3RvcjoKICAgIG5hbWVzcGFjZXM6CiAgICAgIC0gdGVzdGluZwogICAgbGFiZWxTZWxlY3RvcnM6CiAgICAgICdhcHAua3ViZXJuZXRlcy5pby9uYW1lJzogJ2luZGljbycK

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -116,3 +116,9 @@ jobs:
         uses: merkata/github-chaos-actions@master
         env:
           EXPERIMENT_NAME: pod-delete
+
+      - name: Run chaos mesh pod kill action
+        uses: chaos-mesh/chaos-mesh-action@v0.5
+        env:
+          CHAOS_MESH_VERSION: v1.0.0
+          CFG_BASE64: YXBpVmVyc2lvbjogY2hhb3MtbWVzaC5vcmcvdjFhbHBoYTEKa2luZDogUG9kQ2hhb3MKbWV0YWRhdGE6CiAgbmFtZTogcG9kLWtpbGwtZXhhbXBsZQogIG5hbWVzcGFjZTogY2hhb3MtbWVzaApzcGVjOgogIGFjdGlvbjogcG9kLWtpbGwKICBtb2RlOiBvbmUKICBzZWxlY3RvcjoKICAgIG5hbWVzcGFjZXM6CiAgICAgIC0gdGVzdGluZwogICAgbGFiZWxTZWxlY3RvcnM6CiAgICAgICdhcHAua3ViZXJuZXRlcy5pby9uYW1lJzogJ2luZGljbycK

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,6 +14,17 @@ on:
 env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
+  EXPERIMENT_IMAGE: litmuschaos/go-runner
+  EXPERIMENT_IMAGE_TAG: latest
+  JOB_CLEANUP_POLICY: delete
+  CHAOS_NAMESPACE: testing
+  APP_NS: testing
+  APP_LABEL: app.kubernetes.io/name=indico
+  APP_KIND: statefulset
+  IMAGE_PULL_POLICY: Always
+  TOTAL_CHAOS_DURATION: 30
+  CHAOS_INTERVAL: 10
+  FORCE: false
 
 jobs:
   get-images:
@@ -105,65 +116,21 @@ jobs:
         uses: merkata/github-chaos-actions@master
         env:
           EXPERIMENT_NAME: pod-delete
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
-          EXPERIMENT_IMAGE_TAG: latest
-          JOB_CLEANUP_POLICY: delete
-          CHAOS_NAMESPACE: testing
-          APP_NS: testing
-          APP_LABEL: app.kubernetes.io/name=indico
-          APP_KIND: statefulset
-          IMAGE_PULL_POLICY: Always
-          TOTAL_CHAOS_DURATION: 30
-          CHAOS_INTERVAL: 10
-          FORCE: false
 
       - name: Running Litmus pod cpu hog chaos experiment
         uses: merkata/github-chaos-actions@master
         env:
           EXPERIMENT_NAME: pod-cpu-hog
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
-          EXPERIMENT_IMAGE_TAG: latest
-          JOB_CLEANUP_POLICY: delete
-          CHAOS_NAMESPACE: testing
-          APP_NS: testing
-          APP_LABEL: app.kubernetes.io/name=indico
-          APP_KIND: statefulset
-          IMAGE_PULL_POLICY: Always
-          TOTAL_CHAOS_DURATION: 30
-          CHAOS_INTERVAL: 10
-          FORCE: false
 
       - name: Running Litmus pod memory hog chaos experiment
         uses: merkata/github-chaos-actions@master
         env:
           EXPERIMENT_NAME: pod-memory-hog
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
-          EXPERIMENT_IMAGE_TAG: latest
-          JOB_CLEANUP_POLICY: delete
-          CHAOS_NAMESPACE: testing
-          APP_NS: testing
-          APP_LABEL: app.kubernetes.io/name=indico
-          APP_KIND: statefulset
-          IMAGE_PULL_POLICY: Always
-          TOTAL_CHAOS_DURATION: 30
-          CHAOS_INTERVAL: 10
-          FORCE: false
 
       - name: Running Litmus disk fill chaos experiment
         uses: merkata/github-chaos-actions@master
         env:
           EXPERIMENT_NAME: disk-fill
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
-          EXPERIMENT_IMAGE_TAG: latest
-          JOB_CLEANUP_POLICY: delete
-          CHAOS_NAMESPACE: testing
-          APP_NS: testing
-          APP_LABEL: app.kubernetes.io/name=indico
-          APP_KIND: statefulset
-          IMAGE_PULL_POLICY: Always
-          TOTAL_CHAOS_DURATION: 30
-          CHAOS_INTERVAL: 10
-          FORCE: false
 
       - name: Uninstall Litmus
         if: always()

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -117,6 +117,54 @@ jobs:
           CHAOS_INTERVAL: 10
           FORCE: false
 
+      - name: Running Litmus pod cpu hog chaos experiment
+        uses: merkata/github-chaos-actions@master
+        env:
+          EXPERIMENT_NAME: pod-cpu-hog
+          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE_TAG: latest
+          JOB_CLEANUP_POLICY: delete
+          CHAOS_NAMESPACE: testing
+          APP_NS: testing
+          APP_LABEL: app.kubernetes.io/name=indico
+          APP_KIND: statefulset
+          IMAGE_PULL_POLICY: Always
+          TOTAL_CHAOS_DURATION: 30
+          CHAOS_INTERVAL: 10
+          FORCE: false
+
+      - name: Running Litmus pod memory hog chaos experiment
+        uses: merkata/github-chaos-actions@master
+        env:
+          EXPERIMENT_NAME: pod-memory-hog
+          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE_TAG: latest
+          JOB_CLEANUP_POLICY: delete
+          CHAOS_NAMESPACE: testing
+          APP_NS: testing
+          APP_LABEL: app.kubernetes.io/name=indico
+          APP_KIND: statefulset
+          IMAGE_PULL_POLICY: Always
+          TOTAL_CHAOS_DURATION: 30
+          CHAOS_INTERVAL: 10
+          FORCE: false
+
+      - name: Running Litmus disk fill chaos experiment
+        uses: merkata/github-chaos-actions@master
+        env:
+          EXPERIMENT_NAME: disk-fill
+          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE_TAG: latest
+          JOB_CLEANUP_POLICY: delete
+          CHAOS_NAMESPACE: testing
+          APP_NS: testing
+          APP_LABEL: app.kubernetes.io/name=indico
+          APP_KIND: statefulset
+          IMAGE_PULL_POLICY: Always
+          TOTAL_CHAOS_DURATION: 30
+          CHAOS_INTERVAL: 10
+          FORCE: false
+
       - name: Uninstall Litmus
         if: always()
         uses: merkata/github-chaos-actions@master

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -95,14 +95,14 @@ jobs:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Setup Litmus
-        uses: litmuschaos/github-chaos-actions@master
+        uses: merkata/github-chaos-actions@master
         env:
           INSTALL_LITMUS: true
           CHAOS_NAMESPACE: testing
           APP_NS: testing
 
       - name: Running Litmus pod delete chaos experiment
-        uses: litmuschaos/github-chaos-actions@master
+        uses: merkata/github-chaos-actions@master
         env:
           EXPERIMENT_NAME: pod-delete
           EXPERIMENT_IMAGE: litmuschaos/go-runner
@@ -119,6 +119,6 @@ jobs:
 
       - name: Uninstall Litmus
         if: always()
-        uses: litmuschaos/github-chaos-actions@master
+        uses: merkata/github-chaos-actions@master
         env:
           LITMUS_CLEANUP: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -120,5 +120,5 @@ jobs:
       - name: Run chaos mesh pod kill action
         uses: chaos-mesh/chaos-mesh-action@v0.5
         env:
-          CHAOS_MESH_VERSION: v1.0.0
+          CHAOS_MESH_VERSION: v2.4.1
           CFG_BASE64: YXBpVmVyc2lvbjogY2hhb3MtbWVzaC5vcmcvdjFhbHBoYTEKa2luZDogUG9kQ2hhb3MKbWV0YWRhdGE6CiAgbmFtZTogcG9kLWtpbGwtZXhhbXBsZQogIG5hbWVzcGFjZTogY2hhb3MtbWVzaApzcGVjOgogIGFjdGlvbjogcG9kLWtpbGwKICBtb2RlOiBvbmUKICBzZWxlY3RvcjoKICAgIG5hbWVzcGFjZXM6CiAgICAgIC0gdGVzdGluZwogICAgbGFiZWxTZWxlY3RvcnM6CiAgICAgICdhcHAua3ViZXJuZXRlcy5pby9uYW1lJzogJ2luZGljbycK

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,11 @@ name: Tests
 on:
   workflow_call:
   pull_request:
+  push:
+  branches:
+    - 'feat/linters'
+
+
 
 jobs:
   lint-and-unit-test:


### PR DESCRIPTION
This is a draft and a PoC of two possible solutions for chaos testing - Litmus and Chaos Engine. I've included them locally, once we settle for one or the other, the respective code can be opened in our actions repository. A successful run is available at https://github.com/canonical/indico-operator/actions/runs/3431412702

Both Litmus and Chaos Engine actions are not that well supported in my opinion:
for Litmus, I've opened a PR upstream with a fix that is still not addressed two weeks later
for Chaos Engine, the example references Chaos Engine v1.0.0 with v2.4.1 being the latest available, also the master branch has a fix for CRDs that cannot be applied due to the size of the manifest (on `apply` you get a copy of the manifest in the annotations and there is a limitation, you can use `create` instead which does not copy data to the annotations), but there hasn't been any release for a while now

Litmus is better in terms of presenting the result of the test, for Chaos Engine there is no statement that the experiment has run to completion and was successful, so testing in CI/CD doesn't seem suitable.