### PR TITLE
docs(ISD-146): Add Reference

### DIFF
--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -1,0 +1,3 @@
+# Actions
+
+See [Actions](https://charmhub.io/indico/actions).

--- a/docs/reference/configurations.md
+++ b/docs/reference/configurations.md
@@ -1,0 +1,3 @@
+# Configurations
+
+See [Configure](https://charmhub.io/indico/configure).

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -1,0 +1,12 @@
+# Integrations
+
+This charm integrates with:
+
+- [Grafana](https://grafana.com/)
+- [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/#what-is-ingress)
+- [Loki](https://grafana.com/oss/loki/)
+- [PostgreSQL](https://www.postgresql.org/)
+- [Prometheus](https://prometheus.io/)
+- [Redis](https://redis.io/)
+
+See more information in [Charm Architecture](https://charmhub.io/indico/docs/charm-architecture).

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -1,3 +1,5 @@
 # Plugins
 
-Indico provides a number of plugins. You can also configure additional plugins using the `external_plugins` configuration option.
+Indico provides many plugins that can be used to extend functionalities without the need to change the Indico core. See more information in [Extending Indico with plugins](https://docs.getindico.io/en/latest/plugins/).
+
+You can configure additional plugins using the [`external_plugins`](https://charmhub.io/indico/configure#external_plugins) configuration option.

--- a/docs/reference/theme-customisation.md
+++ b/docs/reference/theme-customisation.md
@@ -1,3 +1,0 @@
-# Theme Customisation
-
-Indico offers a framework for customizing the look and feel of your Indico installation. Once you've developed the css and javascript files you need, set the `customization_sources_url` option to the charm to point to the repository for these.

--- a/docs/reference/theme-customization.md
+++ b/docs/reference/theme-customization.md
@@ -2,4 +2,4 @@
 
 Indico offers a framework for customizing the look and feel of your Indico installation. See more information in [Customization](https://docs.getindico.io/en/latest/config/settings/#customization).
 
-Once you've developed the CSS and JavaScript files you need, set the [`customization_sources_url`](https://charmhub.io/indico/configure#customization_sources_url) option to the charm to point to the repository for these.
+Once you've developed the CSS and JavaScript files you need, set the [`customization_sources_url`](https://charmhub.io/indico/configure#customization_sources_url) option of the charm to point to the repository for these.

--- a/docs/reference/theme-customization.md
+++ b/docs/reference/theme-customization.md
@@ -1,0 +1,5 @@
+# Theme Customization
+
+Indico offers a framework for customizing the look and feel of your Indico installation. See more information in [Customization](https://docs.getindico.io/en/latest/config/settings/#customization).
+
+Once you've developed the CSS and JavaScript files you need, set the [`customization_sources_url`](https://charmhub.io/indico/configure#customization_sources_url) option to the charm to point to the repository for these.


### PR DESCRIPTION
Add:
- Actions
- Configurations
- Integrations

Since https://github.com/canonical/upload-charm-docs/issues/26 is in progress and is not possible to add items to the navigation table,  add actions and configurations files with links to corresponding Charmhub pages.

Modify:
- Plugins
- Theme Customization