### PR TITLE
ISD-302-make-chaos-tests-reusable-in-operator-workflows-for-charm-repos

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -5,5 +5,9 @@ on:
 
 jobs:
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@ISD-302-make-chaos-tests-reusable-in-operator-workflows-for-charm-repos
     secrets: inherit
+    with:
+      chaos-enabled: true
+      chaos-experiments: pod-delete
+      chaos-app-label: app.kubernetes.io/name=indico

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -2,13 +2,10 @@ name: Integration tests
 
 on:
   pull_request:
-  push:
-    branches:
-      - 'ISD-302-make-chaos-tests-reusable-in-operator-workflows-for-charm-repos'
 
 jobs:
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@ISD-302-make-chaos-tests-reusable-in-operator-workflows-for-charm-repos
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
       chaos-enabled: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -2,6 +2,9 @@ name: Integration tests
 
 on:
   pull_request:
+  push:
+    branches:
+      - 'ISD-302-make-chaos-tests-reusable-in-operator-workflows-for-charm-repos'
 
 jobs:
   integration-tests:


### PR DESCRIPTION
An implementation of a reusable set of chaos experiments (currently only `pod-delete`) via invoking operator-workflows. This PR is ready for review as the feature landed on operator-workflows repo.