### PR TITLE
Add helpers functions to create the model

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,7 +13,7 @@ from ops.model import WaitingStatus
 from pytest import Config, fixture
 from pytest_operator.plugin import OpsTest
 
-from tests.integration.helpers import app_add_relation, deploy_app, deploy_related_charm
+from tests.integration.helpers import deploy_app, deploy_related_charm, relate_app
 
 
 @fixture(scope="module", name="metadata")
@@ -84,10 +84,10 @@ async def app(
     expected_name = WaitingStatus.name  # type: ignore
     assert ops_test.model.applications[app_name].units[0].workload_status == expected_name
     await asyncio.gather(
-        app_add_relation(ops_test, app_name, "postgresql-k8s:db"),
-        app_add_relation(ops_test, app_name, "redis-broker:redis"),
-        app_add_relation(ops_test, app_name, "redis-cache:redis"),
-        app_add_relation(ops_test, app_name, "nginx-ingress-integrator"),
+        relate_app(ops_test, app_name, "postgresql-k8s:db"),
+        relate_app(ops_test, app_name, "redis-broker:redis"),
+        relate_app(ops_test, app_name, "redis-cache:redis"),
+        relate_app(ops_test, app_name, "nginx-ingress-integrator"),
     )
     await ops_test.model.wait_for_idle(status="active")
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Helper functions for integration tests.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helper functions for integration tests."""
+
+from typing import Optional
+
+from ops.model import Application
+from pytest_operator.plugin import OpsTest
+
+
+async def deploy_related_charm(
+    ops_test: OpsTest,
+    charm_name: str,
+    instance_name: Optional[str] = None,
+    raise_on_error: bool = True,
+    trust: bool = False,
+) -> Application:
+    """Deploy a charm related to our main app, if it's not already deployed."""
+    assert ops_test.model
+    instance_name = instance_name or charm_name
+    if instance_name not in ops_test.model.applications:
+        instance = await ops_test.model.deploy(charm_name, instance_name, trust=trust)
+        await ops_test.model.wait_for_idle(raise_on_error=raise_on_error)
+        return instance
+    return ops_test.model.applications[instance_name]
+
+
+# pylint: disable=dangerous-default-value
+async def deploy_app(
+    ops_test: OpsTest,
+    app_name: str,
+    series: str,
+    resources: dict = {},
+) -> Application:
+    """Deploy our main app, if it's not already deployed."""
+    assert ops_test.model
+    if app_name not in ops_test.model.applications:
+        charm = await ops_test.build_charm(".")
+        application = await ops_test.model.deploy(
+            charm, resources=resources, application_name=app_name, series=series
+        )
+        await ops_test.model.wait_for_idle()
+        return application
+    return ops_test.model.applications[app_name]
+
+
+async def app_add_relation(
+    ops_test: OpsTest,
+    app_name: str,
+    relation_id: str,
+):
+    """Relate to applications if the relation does not already exists."""
+    assert ops_test.model
+    assert ops_test.model.relations
+
+    if not any(filter(lambda x: x.matches(relation_id), ops_test.model.relations)):  # type: ignore
+        await ops_test.model.add_relation(app_name, relation_id)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -80,7 +80,7 @@ async def relate_app(
 
     Args:
         ops_test: The pytest operator plugin instance.
-        app_name: The application name that will be part of the realtion.
+        app_name: The application name that will be part of the relation.
         relation_id: The relation identifier.
 
     Returns:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -20,7 +20,18 @@ async def deploy_related_charm(
     raise_on_error: bool = True,
     trust: bool = False,
 ) -> Application:
-    """Deploy a charm related to our main app, if it's not already deployed."""
+    """Deploy a charm related to our main app, if it's not already deployed.
+
+    Args:
+        ops_test: The pytest operator plugin instance.
+        charm_name: The name of the charm to deploy.
+        instance_name: The name that the instance will have.
+        raise_on_error: Should an Exception be raised if the charm enters an error state.
+        trust: Should we trust the charm to change things on the k8s substrate.
+
+    Returns:
+        The deployed application.
+    """
     assert ops_test.model
     instance_name = instance_name or charm_name
     if instance_name not in ops_test.model.applications:
@@ -36,7 +47,17 @@ async def deploy_app(
     series: str,
     resources: Optional[dict] = None,
 ) -> Application:
-    """Deploy our main app, if it's not already deployed."""
+    """Deploy our main app, if it's not already deployed.
+
+    Args:
+        ops_test: The pytest operator plugin instance.
+        app_name: The name of the application's charm.
+        series: The Ubuntu series with which to deploy the charm.
+        resources: A dict with resources (like container images).
+
+    Returns:
+        The deployed application.
+    """
     assert ops_test.model
     if resources is None:
         resources = {}
@@ -55,7 +76,16 @@ async def relate_app(
     app_name: str,
     relation_id: str,
 ):
-    """Relate to applications if the relation does not already exists."""
+    """Relate to applications if the relation does not already exists.
+
+    Args:
+        ops_test: The pytest operator plugin instance.
+        app_name: The application name that will be part of the realtion.
+        relation_id: The relation identifier.
+
+    Returns:
+        The created relation.
+    """
     assert ops_test.model
     assert ops_test.model.relations
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,12 +36,12 @@ description = Check code against coding style standards
 deps =
     black
     codespell
-    flake8<6.0.0
     flake8-builtins
     flake8-copyright<6.0.0
-    flake8-docstrings>=1.6.0
     flake8-docstrings-complete>=1.0.3
+    flake8-docstrings>=1.6.0
     flake8-test-docs>=1.0
+    flake8<6.0.0
     isort
     mypy
     pep8-naming

--- a/tox.ini
+++ b/tox.ini
@@ -36,12 +36,12 @@ description = Check code against coding style standards
 deps =
     black
     codespell
+    flake8<6.0.0
     flake8-builtins
     flake8-copyright<6.0.0
-    flake8-docstrings-complete>=1.0.3
     flake8-docstrings>=1.6.0
+    flake8-docstrings-complete>=1.0.3
     flake8-test-docs>=1.0
-    flake8<6.0.0
     isort
     mypy
     pep8-naming


### PR DESCRIPTION
The goal is to be able to reuse the same model when replaying the integration tests.  
This can also be helpful to split future integrations tests in multiple files (as the operator-workflows code keeps the model between different integration test modules).