### PR TITLE
Fix dependencies needed for package installation

### DIFF
--- a/indico-nginx.Dockerfile
+++ b/indico-nginx.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && adduser --system --gid ${nginx_gid} --uid ${nginx_uid} --home /srv/indico --disabled-login nginx
 USER nginx
 RUN python3 -m pip install --no-cache-dir --no-warn-script-location --prefer-binary \
-    indico==3.2 \
+    indico==3.2.0 \
     indico-plugin-piwik \
     indico-plugin-storage-s3
 

--- a/indico.Dockerfile
+++ b/indico.Dockerfile
@@ -22,7 +22,7 @@ ENV UWSGI_EMBED_PLUGINS=stats_pusher_statsd
 
 USER indico
 RUN python3 -m pip install --no-cache-dir --no-warn-script-location --prefer-binary \
-    indico==3.2 \
+    indico==3.2.0 \
     indico-plugin-piwik \
     indico-plugin-storage-s3 \
     python-ldap \

--- a/indico.Dockerfile
+++ b/indico.Dockerfile
@@ -3,43 +3,11 @@ FROM ubuntu:jammy as builder
 ARG indico_gid=2000
 ARG indico_uid=2000
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        build-essential \
-        libldap2-dev \
-        libpq-dev \
-        libsasl2-dev \
-        libxmlsec1-dev \
-        pkg-config \
-        python3-dev \
-        python3-pip \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && addgroup --gid ${indico_gid} indico \
-    && adduser --system --gid ${indico_gid} --uid ${indico_uid} --home /srv/indico indico
-
-ENV UWSGI_EMBED_PLUGINS=stats_pusher_statsd
-
-USER indico
-RUN python3 -m pip install --no-cache-dir --no-warn-script-location --prefer-binary \
-    indico==3.2.0 \
-    indico-plugin-piwik \
-    indico-plugin-storage-s3 \
-    python-ldap \
-    python3-saml \
-    uwsgi
-
-FROM ubuntu:jammy as target
-
-COPY --from=builder /srv/indico/.local /srv/indico/.local
-
-ARG indico_gid=2000
-ARG indico_uid=2000
-
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
-    LC_LANG=C.UTF-8
+    LC_LANG=C.UTF-8 \
+    UWSGI_EMBED_PLUGINS=stats_pusher_statsd
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -62,12 +30,19 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && addgroup --gid ${indico_gid} indico \
-    && adduser --system --gid ${indico_gid} --uid ${indico_uid} --home /srv/indico indico \
-    && /bin/bash -c "mkdir -p --mode=775 /srv/indico/{archive,cache,custom,etc,log,tmp}" \
-    && /bin/bash -c "chown indico:indico /srv/indico /srv/indico/{archive,cache,custom,etc,log,tmp,.local}"
+    && adduser --system --gid ${indico_gid} --uid ${indico_uid} --home /srv/indico indico
 
 USER indico
-RUN /srv/indico/.local/bin/indico setup create-symlinks /srv/indico
+RUN python3 -m pip install --no-cache-dir --no-warn-script-location --prefer-binary \
+    indico==3.2.0 \
+    indico-plugin-piwik \
+    indico-plugin-storage-s3 \
+    python-ldap \
+    python3-saml \
+    uwsgi \
+    && /bin/bash -c "mkdir -p --mode=775 /srv/indico/{archive,cache,custom,etc,log,tmp}" \
+    && /bin/bash -c "chown indico:indico /srv/indico /srv/indico/{archive,cache,custom,etc,log,tmp,.local}" \
+    && /srv/indico/.local/bin/indico setup create-symlinks /srv/indico
 
 COPY --chown=indico:indico files/start-indico.sh /srv/indico/
 COPY --chown=indico:indico files/etc/indico/ /etc/

--- a/indico.Dockerfile
+++ b/indico.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy as builder
+FROM ubuntu:jammy
 
 ARG indico_gid=2000
 ARG indico_uid=2000

--- a/indico.Dockerfile
+++ b/indico.Dockerfile
@@ -47,8 +47,11 @@ RUN apt-get update \
         ca-certificates \
         git-core \
         libglib2.0-data \
+        libldap2-dev \
         libpq-dev \
+        libsasl2-dev \
         libxmlsec1-dev \
+        pkg-config \
         postgresql-client \
         python3-dev \
         python3-pip \


### PR DESCRIPTION
Fix dependencies needed for python package installation and pin Indico version to 3.2.0, last version does not require Postgres 13.
As part of this, the Indico image is built as a single stage build. Multistage doesn't provide any advantage.