### PR TITLE
Fix SSO and missing packages issues

### DIFF
--- a/files/start-indico.sh
+++ b/files/start-indico.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-export PATH="$PATH":/srv/indico/.local/bin
 indico db prepare
 indico db upgrade
 indico db --all-plugins upgrade

--- a/indico.Dockerfile
+++ b/indico.Dockerfile
@@ -32,7 +32,6 @@ RUN apt-get update \
     && addgroup --gid ${indico_gid} indico \
     && adduser --system --gid ${indico_gid} --uid ${indico_uid} --home /srv/indico indico
 
-USER indico
 RUN python3 -m pip install --no-cache-dir --no-warn-script-location --prefer-binary \
     indico==3.2.0 \
     indico-plugin-piwik \
@@ -41,8 +40,8 @@ RUN python3 -m pip install --no-cache-dir --no-warn-script-location --prefer-bin
     python3-saml \
     uwsgi \
     && /bin/bash -c "mkdir -p --mode=775 /srv/indico/{archive,cache,custom,etc,log,tmp}" \
-    && /bin/bash -c "chown indico:indico /srv/indico /srv/indico/{archive,cache,custom,etc,log,tmp,.local}" \
-    && /srv/indico/.local/bin/indico setup create-symlinks /srv/indico
+    && /bin/bash -c "chown indico:indico /srv/indico /srv/indico/{archive,cache,custom,etc,log,tmp}" \
+    && indico setup create-symlinks /srv/indico
 
 COPY --chown=indico:indico files/start-indico.sh /srv/indico/
 COPY --chown=indico:indico files/etc/indico/ /etc/

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -313,10 +313,10 @@ class TestCharm(unittest.TestCase):
             storage_dict["s3"],
         )
         auth_providers = literal_eval(updated_plan_env["INDICO_AUTH_PROVIDERS"])
-        self.assertEqual("saml", auth_providers["saml"]["type"])
+        self.assertEqual("saml", auth_providers["ubuntu"]["type"])
         self.assertEqual(
             "https://example.local:8080",
-            auth_providers["saml"]["saml_config"]["sp"]["entityId"],
+            auth_providers["ubuntu"]["saml_config"]["sp"]["entityId"],
         )
         identity_providers = literal_eval(updated_plan_env["INDICO_IDENTITY_PROVIDERS"])
         self.assertEqual("ldap", identity_providers["ldap"]["type"])
@@ -365,10 +365,10 @@ class TestCharm(unittest.TestCase):
             storage_dict["s3"],
         )
         auth_providers = literal_eval(updated_plan_env["INDICO_AUTH_PROVIDERS"])
-        self.assertEqual("saml", auth_providers["saml"]["type"])
+        self.assertEqual("saml", auth_providers["ubuntu"]["type"])
         self.assertEqual(
             "https://example.local:8080",
-            auth_providers["saml"]["saml_config"]["sp"]["entityId"],
+            auth_providers["ubuntu"]["saml_config"]["sp"]["entityId"],
         )
         identity_providers = literal_eval(updated_plan_env["INDICO_IDENTITY_PROVIDERS"])
         self.assertEqual("ldap", identity_providers["ldap"]["type"])


### PR DESCRIPTION
* Fix SSO integration with Canonical's SAML server by renaming the settings dict key
* Install packages as root to guarantee they are executable by any user