### PR TITLE
ci(issues): Sync issues to Jira

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,0 +1,11 @@
+name: Sync issues to Jira
+
+on:
+  issues:
+    # available via github.event.action
+    types: [opened, reopened, closed]
+
+jobs:
+  issues-to-jira:
+    uses: canonical/operator-workflows/.github/workflows/jira.yaml@main
+    secrets: inherit


### PR DESCRIPTION
This PR implements Github to Jira issues sync via github actions. The sync is unidirectional (Github -> Jira).