### PR TITLE
Fix docs link titles

### DIFF
--- a/docs/how-to-guides/hostname-configuration.md
+++ b/docs/how-to-guides/hostname-configuration.md
@@ -1,3 +1,5 @@
+# Configure the external hostname
+
 This charm exposes the `site_url` configuration option to specify the external hostname of the application.
 
 To expose the application it is recommended to set that configuration option and deploy and relate the [Nginx Ingress Integrator Operator](https://charmhub.io/nginx-ingress-integrator), that will be automatically configured with the values provided by the charm.

--- a/docs/how-to-guides/install-plugins.md
+++ b/docs/how-to-guides/install-plugins.md
@@ -1,3 +1,5 @@
+# Install plugins
+
 This charm supports installing both official and custom plugins for Indico, from pypi and from a git repositories.
 
 The `piwik` and `storage-s3` plugins are already packed as part of the charm. The list of available official plugins can be found [here](https://github.com/indico/indico-plugins).

--- a/docs/how-to-guides/proxy-configuration.md
+++ b/docs/how-to-guides/proxy-configuration.md
@@ -1,3 +1,5 @@
+# Proxy configuration
+
 This charm supports several operations that require access to external resources, such as customization or plugins installation, so your environment may not be able to reach those URLs unless through a proxy. The proxy can be configured via two configuration options `http_proxy` for HTTP requests, and `https_proxy` for HTTPS request.
 
 Assuming Indico is already up and running as `indico`, you'll need to run the following commands:

--- a/docs/how-to-guides/s3-configuration.md
+++ b/docs/how-to-guides/s3-configuration.md
@@ -1,3 +1,5 @@
+# S3 configuration
+
 An S3 bucket can be leveraged to serve the static content uploaded to Indico, potentially improving performance. Moreover, it is required when scaling the charm to serve the uploaded files. To configure it to set the appropriate connection parameters in `s3_storage` for your existing bucket `juju config [charm_name] s3_storage=[value]`.
 
 The configuration option `s3_storage` accepts a comma separated list of parameters as in 's3:bucket=my-indico-test-bucket,access_key=12345,secret_key=topsecret'. More details can be found [in Indico's storage S3 documentation](https://github.com/indico/indico-plugins/blob/master/storage_s3/README.md#available-config-options).

--- a/docs/how-to-guides/saml-configuration.md
+++ b/docs/how-to-guides/saml-configuration.md
@@ -1,3 +1,5 @@
+# SAML configuration
+
 To configure Indico's SAML integration you'll have to set `saml_target_url` with the URL for your SAML server by running `juju config [charm_name] saml_target_url=[value]`.
 
 For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/indico/configure).

--- a/docs/how-to-guides/smtp-configuration.md
+++ b/docs/how-to-guides/smtp-configuration.md
@@ -1,3 +1,5 @@
+# SMTP configuration
+
 To configure Indico's SMTP you'll have to set the following configuration options with the appropriate values for your SMTP server by running `juju config [charm_name] [configuration]=[value]`.
 
 Set `smtp_server`to the SMTP server IP or hostname, `smtp_port` for the SMTP sever port if different from the default. If authentication is needed, the credentials can be set with `smtp_login`and `smtp_password`. Note that TLS can be turned on and off with `smtp_use_tls`.

--- a/docs/how-to-guides/theme-customization.md
+++ b/docs/how-to-guides/theme-customization.md
@@ -1,3 +1,5 @@
+# Theme customization
+
 This charm supports providing static source files for customizing Indico look and feel. Details on how those files should look like can be consulted in [Indico's official documentation](https://docs.getindico.io/en/stable/config/settings/#customization).
 
 If you wish to apply a set of customization files, set the configuration option `customization_sources_url` to the URL of the git repository containing them `juju config [charm_name] customization_sources_url=[value]`. For debugging purposes, you may also want to enable `customization_debug` to get meaningful log messages when the files are accessed.


### PR DESCRIPTION
Charmhub seems to require a title per document to be able to name the left index appropriately.