### PR TITLE
Adjust memberOf casing to fix group membership

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -659,7 +659,7 @@ class IndicoOperatorCharm(CharmBase):
                     "gid": "cn",
                     "group_base": "dc=canonical,dc=com",
                     "group_filter": "(objectClass=groupofnames)",
-                    "member_of_attr": "memberof",
+                    "member_of_attr": "memberOf",
                     "ad_group_style": False,
                 }
                 identity_providers = {


### PR DESCRIPTION
This should fix group membership checks, our ldap server uses the default `memberOf` instead of `memberof`