### PR TITLE
Pin libjuju to version 2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -140,7 +140,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju
+    juju>=2.9,<3
     pytest
     pytest-asyncio
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -140,7 +140,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju>=2.9,<3
+    juju>=2,<3
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
Pin libjuju to version 2 since version 3 breaks compatibility https://github.com/juju/python-libjuju/releases/tag/3.1.0.1