### PR TITLE
Adjust memberOf casing to fix group membership (#236)

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -659,7 +659,7 @@ class IndicoOperatorCharm(CharmBase):
                     "gid": "cn",
                     "group_base": "dc=canonical,dc=com",
                     "group_filter": "(objectClass=groupofnames)",
-                    "member_of_attr": "memberof",
+                    "member_of_attr": "memberOf",
                     "ad_group_style": False,
                 }
                 identity_providers = {

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -55,24 +55,24 @@ async def app(
     """
     assert ops_test.model
     # Deploy relations to speed up overall execution
-    await asyncio.gather(
+    dependencies = asyncio.gather(
         ops_test.model.deploy("postgresql-k8s"),
         ops_test.model.deploy("redis-k8s", "redis-broker"),
         ops_test.model.deploy("redis-k8s", "redis-cache"),
         ops_test.model.deploy("nginx-ingress-integrator", trust=True),
     )
 
-    charm = await ops_test.build_charm(".")
     resources = {
         "indico-image": pytestconfig.getoption("--indico-image"),
         "indico-nginx-image": pytestconfig.getoption("--indico-nginx-image"),
     }
     resources.update(prometheus_exporter_images)
-
+    charm = await ops_test.build_charm(".")
     application = await ops_test.model.deploy(
         charm, resources=resources, application_name=app_name, series="focal"
     )
 
+    await dependencies
     await asyncio.gather(
         ops_test.model.add_relation(app_name, "postgresql-k8s:db"),
         ops_test.model.add_relation(app_name, "redis-broker"),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,7 @@ from typing import Dict
 
 import pytest_asyncio
 import yaml
+from ops.model import WaitingStatus
 from pytest import Config, fixture
 from pytest_operator.plugin import OpsTest
 
@@ -73,6 +74,9 @@ async def app(
     )
 
     await dependencies
+    # Add required relations, mypy has difficulty with WaitingStatus
+    expected_name = WaitingStatus.name  # type: ignore
+    assert ops_test.model.applications[app_name].units[0].workload_status == expected_name
     await asyncio.gather(
         ops_test.model.add_relation(app_name, "postgresql-k8s:db"),
         ops_test.model.add_relation(app_name, "redis-broker"),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,6 @@ from typing import Dict
 
 import pytest_asyncio
 import yaml
-from ops.model import WaitingStatus
 from pytest import Config, fixture
 from pytest_operator.plugin import OpsTest
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -73,11 +73,7 @@ async def app(
     application = await ops_test.model.deploy(
         charm, resources=resources, application_name=app_name, series="focal"
     )
-    await ops_test.model.wait_for_idle()
 
-    # Add required relations, mypy has difficulty with WaitingStatus
-    expected_name = WaitingStatus.name  # type: ignore
-    assert ops_test.model.applications[app_name].units[0].workload_status == expected_name
     await asyncio.gather(
         ops_test.model.add_relation(app_name, "postgresql-k8s:db"),
         ops_test.model.add_relation(app_name, "redis-broker"),

--- a/tox.ini
+++ b/tox.ini
@@ -146,4 +146,4 @@ deps =
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -tb native --ignore={[vars]tst_path}unit --log-cli-level=WARNING -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -140,6 +140,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
+    # Last compatible version with Juju 2.9
     juju==3.0.4
     pytest
     pytest-asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -140,7 +140,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju
+    juju>=2,<3
     pytest
     pytest-asyncio
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -140,7 +140,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju>=2,<3
+    juju==3.0.4
     pytest
     pytest-asyncio
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -146,4 +146,4 @@ deps =
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
-    pytest --tb native --ignore={[vars]tst_path}unit --log-cli-level=WARNING -s {posargs}
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -146,4 +146,4 @@ deps =
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -tb native --ignore={[vars]tst_path}unit --log-cli-level=WARNING -s {posargs}
+    pytest --tb native --ignore={[vars]tst_path}unit --log-cli-level=WARNING -s {posargs}


### PR DESCRIPTION
Re-created this PR to enable tests to run with secrets: https://github.com/canonical/indico-operator/pull/236

Improvements on parallelization for integration test: parallel deployment of dependencies and building of the charm