### PR TITLE
fix(ISD-405): Increase proxy read timeout in NGINX

### DIFF
--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -58,6 +58,7 @@ http {
       proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
       proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_read_timeout 300;
       proxy_pass http://localhost:8081;
 
       location ~ ^/static/custom/(.*)$ {

--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -58,8 +58,19 @@ http {
       proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
       proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_read_timeout 300;
       proxy_pass http://localhost:8081;
+
+      location ~ ^/event/[0-9]+/manage/registration/[0-9]+/registrations/(import|email)$ {
+        proxy_read_timeout 300;
+        proxy_hide_header Cache-Control;
+        add_header Cache-Control 'no-cache,private';
+        add_header X-Content-Type-Options 'nosniff';
+        add_header X-Frame-Options 'SAMEORIGIN';
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass http://localhost:8081;
+      }
 
       location ~ ^/static/custom/(.*)$ {
         expires 1m;


### PR DESCRIPTION
There are some long operations (import registrants, for example) that require more time to finish. 

This PR changes the proxy_read_timeout (default 60s) to 300s (5 minutes) to prevent the user to receive an HTTP 504 Gateway Timeout error.

Local tests showed that this was enough to import ~10000 registrants at once (took ~3min).