### PR TITLE
ISD-382: Remove Content-Security-Policy header

### DIFF
--- a/ZAP.md
+++ b/ZAP.md
@@ -51,3 +51,7 @@ More information in [eval](https://developer.mozilla.org/en-US/docs/Web/JavaScri
 Permissions are features offered by the browser through an API. You have to specify every permission separately, so setting a value for this header could negatively impact the user experience.
 
 More information in [Permissions Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy).
+
+## 10038   IGNORE   (Content Security Policy (CSP) Header Not Set)
+
+By enabling CSP Header, some features while creating events don't work as expected so we are ignoring this alert.

--- a/nginx_rock/etc/common_headers.conf
+++ b/nginx_rock/etc/common_headers.conf
@@ -1,5 +1,4 @@
 add_header X-Content-Type-Options 'nosniff';
 add_header X-Frame-Options 'SAMEORIGIN';
-add_header Content-Security-Policy "default-src 'self';form-action 'self';frame-ancestors 'self';" always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
 add_header X-XSS-Protection "1; mode=block";

--- a/zap_rules.tsv
+++ b/zap_rules.tsv
@@ -9,4 +9,5 @@
 10054	IGNORE	(Cookie without SameSite Attribute)
 10110	IGNORE	(Dangerous JS Functions)
 10063-1	IGNORE	(Permissions Policy Header Not Set)
+10038	IGNORE	(Content Security Policy (CSP) Header Not Set)
 


### PR DESCRIPTION
The Content-Security-Policy is blocking some features while creating events so this PR removes it.

Here what the console shows while clicking in Create Event button:

![image](https://user-images.githubusercontent.com/12564014/223748870-a89f217d-e926-4734-8459-4f2a2fd95234.png)
