### PR TITLE
feat(ISD-260): Add anonymize-user action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -16,3 +16,4 @@ anonymize-user:
     email:
       type: string
       description: User email (or a list of emails separated by comma). Maximum of 50 emails.
+  required: [email]

--- a/actions.yaml
+++ b/actions.yaml
@@ -15,4 +15,4 @@ anonymize-user:
   params:
     email:
       type: string
-      description: User email.
+      description: User email (or a list of emails separated by comma)

--- a/actions.yaml
+++ b/actions.yaml
@@ -11,7 +11,7 @@ add-admin:
       description: User password.
   required: [email, password]
 anonymize-user:
-  description: Anonymize user in Indico
+  description: Anonymize stored personal data to facilitate GDPR compliance
   params:
     email:
       type: string

--- a/actions.yaml
+++ b/actions.yaml
@@ -15,4 +15,4 @@ anonymize-user:
   params:
     email:
       type: string
-      description: User email (or a list of emails separated by comma)
+      description: User email (or a list of emails separated by comma). Maximum of 50 emails.

--- a/actions.yaml
+++ b/actions.yaml
@@ -10,3 +10,9 @@ add-admin:
       type: string
       description: User password.
   required: [email, password]
+anonymize-user:
+  description: Anonymize user in Indico
+  params:
+    email:
+      type: string
+      description: User email.

--- a/indico_rock/plugins/anonymize/README.md
+++ b/indico_rock/plugins/anonymize/README.md
@@ -1,0 +1,3 @@
+# Anonymize Plugin
+
+Extends the indico CLI to add a non-interactive way to anonymize users

--- a/indico_rock/plugins/anonymize/anonymize/__init__.py
+++ b/indico_rock/plugins/anonymize/anonymize/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Anonymize users non-interactively."""

--- a/indico_rock/plugins/anonymize/anonymize/cli.py
+++ b/indico_rock/plugins/anonymize/anonymize/cli.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Create users non-interactively."""
+
+import click
+from hashlib import sha512
+from indico.cli.core import cli_group
+from indico.core.db import db
+from indico.modules.auth import Identity
+from indico.modules.users import User
+from indico.modules.users.operations import create_user
+from indico.modules.users.util import search_users
+from indico.util.date_time import now_utc
+
+
+@cli_group(name="anonymize")
+def cli():
+    """Anonymize users non-interactively."""
+
+# Extracted from:
+# https://github.com/bpedersen2/indico-cron-advanced-cleaner/
+def anonymize_deleted_user(user):
+    """Anonymize user by erasing specific attributes."""
+
+    _anon_attrs = ['first_name', 'last_name', 'phone', 'address',]
+    _clear_attrs_str = ['affiliation', 'email', 'secondary_emails', ]
+    _clear_attrs_set = ['favorite_users', 'favorite_categories', 'identities']
+    _clear_attrs_list = ['old_api_keys',]
+
+
+    for attr in _clear_attrs_str:
+        setattr(user, attr, '')
+
+    for attr in _clear_attrs_set:
+        setattr(user, attr, set())
+
+    for attr in _clear_attrs_list:
+        setattr(user, attr, list())
+
+    for attr in _anon_attrs:
+        val = getattr(user, attr)
+        new_hash = sha512(val.encode('utf-8')+now_utc().isoformat().encode('utf-8')).hexdigest()[:12]
+        setattr(user, attr, new_hash)
+
+@cli.command("user")
+@click.argument("email", type=str)
+@click.pass_context
+def anonymize_user(ctx, email):
+    """Anonymize user non-interactively."""
+
+    email = email.lower()
+
+    if email == "":
+        click.secho("E-mail should not be empty", fg="red")
+        ctx.exit(1)
+
+    users = User.query.filter(User.all_emails == email)
+    if not users.has_rows():
+        click.secho("User not found", fg="red")
+        ctx.exit(1)
+    user = user.first()
+    # First we mark as deleted so won't appear in any form
+    user.is_deleted = True
+    anonymize_deleted_user(user)
+    db.session.commit()  # pylint: disable=no-member
+
+    # Validate the changes
+    res = search_users(
+        exact=True,
+        include_deleted=True,
+        include_pending=False,
+        include_blocked=False,
+        external=False,
+        allow_system_user=False,
+        email=email,
+    )
+
+    user = res.pop()
+
+    if not user.is_deleted:
+        click.secho("User was not anonymized", fg="red")
+        ctx.exit(1)
+
+    click.secho(f'User with email "{email}" correctly anonymized', fg="green")

--- a/indico_rock/plugins/anonymize/anonymize/cli.py
+++ b/indico_rock/plugins/anonymize/anonymize/cli.py
@@ -15,10 +15,24 @@ from indico.modules.users.util import search_users
 from indico.util.date_time import now_utc
 import re
 
-CLEAN_ATTRS_STR = ['affiliation', 'email', 'secondary_emails', ]
-CLEAN_ATTRS_SET= ['favorite_users', 'favorite_categories', 'identities']
-CLEAN_ATTRS_LIST = ['old_api_keys',]
-CLEAN_ATTRS_ANON = ['first_name', 'last_name', 'phone', 'address',]
+
+EMPTY_LIST = lambda _: list()
+EMPTY_SET = lambda _: set()
+EMPTY_VAL = lambda _: ''
+HASH_VAL = lambda val: _hash(val)
+CLEAN_ATTRS = {
+    'affiliation' : EMPTY_VAL,
+    'email': EMPTY_VAL,
+    'secondary_emails': EMPTY_VAL,
+    'favorite_users': EMPTY_SET,
+    'favorite_categories': EMPTY_SET,
+    'identities': EMPTY_SET,
+    'old_api_keys': EMPTY_LIST,
+    'first_name': HASH_VAL,
+    'last_name': HASH_VAL,
+    'phone': HASH_VAL,
+    'address': HASH_VAL,
+}
 
 @cli_group(name="anonymize")
 def cli():
@@ -31,10 +45,12 @@ def _hash(val: str) -> str:
 
     Args:
         val: The string from the hash should be created
+    Returns:
+        First 12 characters from encoded data in hexadecimal format
     """
     return sha512(val.encode('utf-8')+now_utc().isoformat().encode('utf-8')).hexdigest()[:12]
 
-# Extracted from:
+# Based on:
 # https://github.com/bpedersen2/indico-cron-advanced-cleaner/
 def anonymize_deleted_user(user: User):
     """Anonymize user by erasing specific attributes.
@@ -42,30 +58,17 @@ def anonymize_deleted_user(user: User):
     Args:
         user: Indico user
     """
+    for attr, anonymize_val in CLEAN_ATTRS.items():
+        current_val = getattr(user, attr)
+        setattr(user, attr, anonymize_val(current_val))
 
-    for attr in CLEAN_ATTRS_STR:
-        setattr(user, attr, '')
-
-    for attr in CLEAN_ATTRS_SET:
-        setattr(user, attr, set())
-
-    for attr in CLEAN_ATTRS_LIST:
-        setattr(user, attr, list())
-
-    for attr in CLEAN_ATTRS_ANON:
-        setattr(user, attr, _hash(getattr(user, attr)))
-
-# Extracted from:
-# https://github.com/bpedersen2/indico-cron-advanced-cleaner/
-def anonymize_registrations(user: User):
-    """Anonymize user by erasing registrations attributes.
+def anonymize_registration(registration: Registration):
+    """Anonymize registration by changing specific attributes.
 
     Args:
-        user: Indico user
+        registration (Registration): User registration_
     """
-    registrations = Registration.query.filter(Registration.user_id == user.id)
-    for registration in registrations:
-        for fid, rdata in registration.data_by_field.items():
+    for fid, rdata in registration.data_by_field.items():
             fieldtype = RegistrationFormField.get(oid=fid).input_type
             if fieldtype in ('text', 'textarea'):
                 rdata.data = _hash(rdata.data)
@@ -79,13 +82,26 @@ def anonymize_registrations(user: User):
             elif fieldtype == 'country':
                 # Keep country for now
                 pass
-        # other field types are not touched (choice, mulitchoice, radio)
+        # other field types are not touched (choice, multiple choice, radio)
 
-        registration.first_name = _hash(registration.first_name)
-        registration.last_name = _hash(registration.last_name)
-        registration.email = _hash(registration.email)
-        if registration.user:
-            registration.user = None
+    registration.first_name = _hash(registration.first_name)
+    registration.last_name = _hash(registration.last_name)
+    registration.email = _hash(registration.email)
+    if registration.user:
+        registration.user = None
+
+# Based on:
+# https://github.com/bpedersen2/indico-cron-advanced-cleaner/
+def anonymize_registrations(user: User):
+    """Anonymize user by erasing registrations attributes.
+
+    Args:
+        user: Indico user
+    """
+    registrations = Registration.query.filter(Registration.user_id == user.id)
+    for registration in registrations:
+        anonymize_registration(registration)
+    # db.session has commit()
     db.session.commit()  # pylint: disable=no-member
 
 @cli.command("user")

--- a/indico_rock/plugins/anonymize/anonymize/cli.py
+++ b/indico_rock/plugins/anonymize/anonymize/cli.py
@@ -4,13 +4,14 @@
 
 """Anonymize users non-interactively."""
 
+import uuid
+
 import click
 from indico.cli.core import cli_group
 from indico.core.db import db
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
 from indico.modules.events.registration.models.registrations import Registration
 from indico.modules.users import User
-import uuid
 
 CLEAN_ATTRS = {
     "affiliation": str,

--- a/indico_rock/plugins/anonymize/anonymize/cli.py
+++ b/indico_rock/plugins/anonymize/anonymize/cli.py
@@ -71,7 +71,7 @@ def anonymize_registration(registration: Registration):
         if fieldtype in ("text", "textarea"):
             rdata.data = _hash(rdata.data)
         elif fieldtype == "email":
-            rdata.data = _hash(rdata.data) + "@invalid.invalid"
+            rdata.data = f"{_hash(rdata.data)}@invalid.invalid"
         elif fieldtype == "phone":
             rdata.data = "(+00) 0000000"
         elif fieldtype == "date":

--- a/indico_rock/plugins/anonymize/anonymize/cli.py
+++ b/indico_rock/plugins/anonymize/anonymize/cli.py
@@ -26,7 +26,7 @@ def cli():
 
 # Extracted from:
 # https://github.com/bpedersen2/indico-cron-advanced-cleaner/
-def _hash(val: str):
+def _hash(val: str) -> str:
     """Create hash of val.
 
     Args:
@@ -107,8 +107,8 @@ def anonymize_user(ctx, email):
 
     users = User.query.filter(User.all_emails == email)
     if not users.has_rows():
-        click.secho("User not found", fg="red")
-        ctx.exit(1)
+        click.secho("User not found", fg="yellow")
+        ctx.exit(0)
     user = users.first()
 
     # We mark as deleted so won't appear in search users forms

--- a/indico_rock/plugins/anonymize/anonymize/cli.py
+++ b/indico_rock/plugins/anonymize/anonymize/cli.py
@@ -4,39 +4,32 @@
 
 """Anonymize users non-interactively."""
 
-import click
 from hashlib import sha512
+
+import click
 from indico.cli.core import cli_group
 from indico.core.db import db
-from indico.modules.events.registration.models.registrations import Registration
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
+from indico.modules.events.registration.models.registrations import Registration
 from indico.modules.users import User
-from indico.modules.users.util import search_users
 from indico.util.date_time import now_utc
-import re
 
-
-EMPTY_LIST = lambda _: list()
-EMPTY_SET = lambda _: set()
-EMPTY_VAL = lambda _: str
-HASH_VAL = lambda val: _hash(val)
 CLEAN_ATTRS = {
-    'affiliation' : EMPTY_VAL,
-    'email': EMPTY_VAL,
-    'secondary_emails': EMPTY_VAL,
-    'favorite_users': EMPTY_SET,
-    'favorite_categories': EMPTY_SET,
-    'identities': EMPTY_SET,
-    'old_api_keys': EMPTY_LIST,
-    'first_name': HASH_VAL,
-    'last_name': HASH_VAL,
-    'phone': HASH_VAL,
-    'address': HASH_VAL,
+    "affiliation": str(),
+    "email": str(),
+    "secondary_emails": str(),
+    "favorite_users": set(),
+    "favorite_categories": set(),
+    "identities": set(),
+    "old_api_keys": [],
 }
+HASH_ATTRS = ["first_name", "last_name", "phone", "address"]
+
 
 @cli_group(name="anonymize")
 def cli():
     """Anonymize users non-interactively."""
+
 
 # Extracted from:
 # https://github.com/bpedersen2/indico-cron-advanced-cleaner/
@@ -48,7 +41,8 @@ def _hash(val: str) -> str:
     Returns:
         First 12 characters from encoded data in hexadecimal format
     """
-    return sha512(val.encode('utf-8')+now_utc().isoformat().encode('utf-8')).hexdigest()[:12]
+    return sha512(val.encode("utf-8") + now_utc().isoformat().encode("utf-8")).hexdigest()[:12]
+
 
 # Based on:
 # https://github.com/bpedersen2/indico-cron-advanced-cleaner/
@@ -60,7 +54,11 @@ def anonymize_deleted_user(user: User):
     """
     for attr, anonymize_val in CLEAN_ATTRS.items():
         current_val = getattr(user, attr)
-        setattr(user, attr, anonymize_val(current_val))
+        setattr(user, attr, anonymize_val)
+    for attr in HASH_ATTRS:
+        current_val = getattr(user, attr)
+        setattr(user, attr, _hash(current_val))
+
 
 def anonymize_registration(registration: Registration):
     """Anonymize registration by changing specific attributes.
@@ -70,16 +68,16 @@ def anonymize_registration(registration: Registration):
     """
     for fid, rdata in registration.data_by_field.items():
         fieldtype = RegistrationFormField.get(oid=fid).input_type
-        if fieldtype in ('text', 'textarea'):
+        if fieldtype in ("text", "textarea"):
             rdata.data = _hash(rdata.data)
-        elif fieldtype == 'email':
-            rdata.data = _hash(rdata.data) + '@invalid.invalid'
-        elif fieldtype == 'phone':
-            rdata.data = '(+00) 0000000'
-        elif fieldtype == 'date':
+        elif fieldtype == "email":
+            rdata.data = _hash(rdata.data) + "@invalid.invalid"
+        elif fieldtype == "phone":
+            rdata.data = "(+00) 0000000"
+        elif fieldtype == "date":
             # Keep dates for now
             pass
-        elif fieldtype == 'country':
+        elif fieldtype == "country":
             # Keep country for now
             pass
         # other field types are not touched (choice, multiple choice, radio)
@@ -89,6 +87,7 @@ def anonymize_registration(registration: Registration):
     registration.email = _hash(registration.email)
     if registration.user:
         registration.user = None
+
 
 # Based on:
 # https://github.com/bpedersen2/indico-cron-advanced-cleaner/
@@ -103,6 +102,7 @@ def anonymize_registrations(user: User):
         anonymize_registration(registration)
     # db.session has commit()
     db.session.commit()  # pylint: disable=no-member
+
 
 @cli.command("user")
 @click.argument("email", type=str)

--- a/indico_rock/plugins/anonymize/anonymize/cli.py
+++ b/indico_rock/plugins/anonymize/anonymize/cli.py
@@ -4,6 +4,7 @@
 
 """Anonymize users non-interactively."""
 
+import typing
 import uuid
 
 import click
@@ -13,22 +14,6 @@ from indico.modules.events.registration.models.form_fields import RegistrationFo
 from indico.modules.events.registration.models.registrations import Registration
 from indico.modules.users import User
 
-CLEAN_ATTRS = {
-    "affiliation": str,
-    "email": str,
-    "secondary_emails": str,
-    "favorite_users": set,
-    "favorite_categories": set,
-    "identities": set,
-    "old_api_keys": list,
-}
-HASH_ATTRS = ["first_name", "last_name", "phone", "address"]
-
-
-@cli_group(name="anonymize")
-def cli():
-    """Anonymize users non-interactively."""
-
 
 def _generate_uuid() -> str:
     """Generate UUID for fake values
@@ -37,6 +22,26 @@ def _generate_uuid() -> str:
         str: UUID
     """
     return str(uuid.uuid4())
+
+
+CLEAN_ATTRS: typing.Dict[str, typing.Callable] = {
+    "affiliation": str,
+    "email": str,
+    "secondary_emails": str,
+    "favorite_users": set,
+    "favorite_categories": set,
+    "identities": set,
+    "old_api_keys": list,
+    "first_name": _generate_uuid,
+    "last_name": _generate_uuid,
+    "phone": _generate_uuid,
+    "address": _generate_uuid,
+}
+
+
+@cli_group(name="anonymize")
+def cli():
+    """Anonymize users non-interactively."""
 
 
 # Based on:
@@ -49,8 +54,6 @@ def anonymize_deleted_user(user: User):
     """
     for attr, anonymize_val in CLEAN_ATTRS.items():
         setattr(user, attr, anonymize_val())
-    for attr in HASH_ATTRS:
-        setattr(user, attr, _generate_uuid())
 
 
 def anonymize_registration(registration: Registration):

--- a/indico_rock/plugins/anonymize/anonymize/cli.py
+++ b/indico_rock/plugins/anonymize/anonymize/cli.py
@@ -96,8 +96,6 @@ def anonymize_registrations(user: User):
     registrations = Registration.query.filter(Registration.user_id == user.id)
     for registration in registrations:
         anonymize_registration(registration)
-    # db.session has commit()
-    db.session.commit()  # pylint: disable=no-member
 
 
 @cli.command("user")
@@ -128,6 +126,9 @@ def anonymize_user(ctx, email):
     anonymize_deleted_user(user)
     # Anonymize registrations
     anonymize_registrations(user)
+
+    # db.session has commit()
+    db.session.commit()  # pylint: disable=no-member
 
     # Validate the changes
     users = User.query.filter(User.all_emails == email)

--- a/indico_rock/plugins/anonymize/anonymize/cli.py
+++ b/indico_rock/plugins/anonymize/anonymize/cli.py
@@ -44,7 +44,7 @@ def anonymize_deleted_user(user: User):
     for attr in CLEAN_ATTRS_ANON:
         val = getattr(user, attr)
         new_hash = sha512(val.encode('utf-8')+now_utc().isoformat().encode('utf-8')).hexdigest()[:12]
-        setattr(user, attr, new_hash)
+        getattr(user, attr, new_hash)
 
 def is_anonymized(user: User) -> bool:
     """Check if user is anonymized.
@@ -69,10 +69,8 @@ def is_anonymized(user: User) -> bool:
 
     for attr in CLEAN_ATTRS_ANON:
         hash_regex = re.compile('^[a-fA-F0-9]{12}$')
-        
-        val = getattr(user, attr)
-        new_hash = sha512(val.encode('utf-8')+now_utc().isoformat().encode('utf-8')).hexdigest()[:12]
-        setattr(user, attr, new_hash)
+        if not hash_regex.match(getattr(user, attr)):
+            return False
 
 @cli.command("user")
 @click.argument("email", type=str)
@@ -114,7 +112,7 @@ def anonymize_user(ctx, email):
 
     user = res.pop()
 
-    if not user.is_deleted:
+    if not user.is_deleted or not is_anonymized(user):
         click.secho("User was not anonymized", fg="red")
         ctx.exit(1)
 

--- a/indico_rock/plugins/anonymize/anonymize/cli.py
+++ b/indico_rock/plugins/anonymize/anonymize/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3 -W ignore::UserWarning
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/indico_rock/plugins/anonymize/anonymize/cli.py
+++ b/indico_rock/plugins/anonymize/anonymize/cli.py
@@ -18,7 +18,7 @@ import re
 
 EMPTY_LIST = lambda _: list()
 EMPTY_SET = lambda _: set()
-EMPTY_VAL = lambda _: ''
+EMPTY_VAL = lambda _: str
 HASH_VAL = lambda val: _hash(val)
 CLEAN_ATTRS = {
     'affiliation' : EMPTY_VAL,
@@ -69,19 +69,19 @@ def anonymize_registration(registration: Registration):
         registration (Registration): User registration_
     """
     for fid, rdata in registration.data_by_field.items():
-            fieldtype = RegistrationFormField.get(oid=fid).input_type
-            if fieldtype in ('text', 'textarea'):
-                rdata.data = _hash(rdata.data)
-            elif fieldtype == 'email':
-                rdata.data = _hash(rdata.data) + '@invalid.invalid'
-            elif fieldtype == 'phone':
-                rdata.data = '(+00) 0000000'
-            elif fieldtype == 'date':
-                # Keep dates for now
-                pass
-            elif fieldtype == 'country':
-                # Keep country for now
-                pass
+        fieldtype = RegistrationFormField.get(oid=fid).input_type
+        if fieldtype in ('text', 'textarea'):
+            rdata.data = _hash(rdata.data)
+        elif fieldtype == 'email':
+            rdata.data = _hash(rdata.data) + '@invalid.invalid'
+        elif fieldtype == 'phone':
+            rdata.data = '(+00) 0000000'
+        elif fieldtype == 'date':
+            # Keep dates for now
+            pass
+        elif fieldtype == 'country':
+            # Keep country for now
+            pass
         # other field types are not touched (choice, multiple choice, radio)
 
     registration.first_name = _hash(registration.first_name)

--- a/indico_rock/plugins/anonymize/anonymize/cli.py
+++ b/indico_rock/plugins/anonymize/anonymize/cli.py
@@ -123,7 +123,7 @@ def anonymize_user(ctx, email):
 
     users = User.query.filter(User.all_emails == email)
     if not users.has_rows():
-        click.secho("User not found", fg="yellow")
+        click.secho(f"No user found for email {email}", fg="yellow")
         ctx.exit(0)
     user = users.first()
 
@@ -136,7 +136,7 @@ def anonymize_user(ctx, email):
     # Validate the changes
     users = User.query.filter(User.all_emails == email)
     if users.has_rows():
-        click.secho("User was not anonymized", fg="red")
+        click.secho("User with email {email} was not anonymized", fg="red")
         ctx.exit(1)
 
-    click.secho(f'User with email "{email}" correctly anonymized', fg="green")
+    click.secho(f"User with email {email} correctly anonymized", fg="green")

--- a/indico_rock/plugins/anonymize/anonymize/plugin.py
+++ b/indico_rock/plugins/anonymize/anonymize/plugin.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Connect our CLI plugin to the existing Indico's CLI."""
+
+from autocreate.cli import cli
+from indico.core import signals
+from indico.core.plugins import IndicoPlugin
+
+
+class AutocreatePlugin(IndicoPlugin):
+    """Autocreate
+
+    Provides a way to non-interactively create users via Indico's CLI
+    """
+
+    def init(self):
+        super().init()
+        self.connect(signals.plugin.cli, self._extend_indico_cli)
+
+    def _extend_indico_cli(self, *_, **__):
+        return cli

--- a/indico_rock/plugins/anonymize/anonymize/plugin.py
+++ b/indico_rock/plugins/anonymize/anonymize/plugin.py
@@ -4,15 +4,15 @@
 
 """Connect our CLI plugin to the existing Indico's CLI."""
 
-from autocreate.cli import cli
+from anonymize.cli import cli
 from indico.core import signals
 from indico.core.plugins import IndicoPlugin
 
 
-class AutocreatePlugin(IndicoPlugin):
-    """Autocreate
+class AnonymizePlugin(IndicoPlugin):
+    """Anonymize
 
-    Provides a way to non-interactively create users via Indico's CLI
+    Provides a way to non-interactively anonymize users via Indico's CLI
     """
 
     def init(self):

--- a/indico_rock/plugins/anonymize/setup.cfg
+++ b/indico_rock/plugins/anonymize/setup.cfg
@@ -1,0 +1,28 @@
+[metadata]
+name = indico-plugin-anonymize
+version = 3.2
+description = Extends the indico CLI to add a non-interactive way to anonymize users
+long_description = file: README.md
+long_description_content_type = text/markdown; charset=UTF-8; variant=GFM
+url = https://github.com/canonical/indico-operator
+license = Apache License 2.0
+author = launchpad.net/~canonical-is-devops
+author_email = is-devops-team@canonical.com
+classifiers =
+    Environment :: Plugins
+    Environment :: Web Environment
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+
+[options]
+packages = find:
+zip_safe = false
+include_package_data = true
+python_requires = >=3.9.0, <3.11
+install_requires =
+    indico>=3.2
+
+[options.entry_points]
+indico.plugins =
+    autocreate = autocreate.plugin:AutocreatePlugin

--- a/indico_rock/plugins/anonymize/setup.cfg
+++ b/indico_rock/plugins/anonymize/setup.cfg
@@ -25,4 +25,4 @@ install_requires =
 
 [options.entry_points]
 indico.plugins =
-    autocreate = autocreate.plugin:AutocreatePlugin
+    anonymize = anonymize.plugin:AnonymizePlugin

--- a/indico_rock/plugins/anonymize/setup.py
+++ b/indico_rock/plugins/anonymize/setup.py
@@ -1,0 +1,5 @@
+"""Extends the indico CLI to add a non-interactive way to anonymize users."""
+
+from setuptools import setup
+
+setup()

--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -56,7 +56,6 @@ parts:
         indico==3.2.0 \
         indico-plugin-piwik \
         indico-plugin-storage-s3 \
-        git+https://github.com/bpedersen2/indico-cron-advanced-cleaner \
         python3-saml \
         python-ldap \
         uwsgi \

--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -59,7 +59,7 @@ parts:
         python3-saml \
         python-ldap \
         uwsgi \
-        ./autocreate
+        ./autocreate \
         ./anonymize
     override-prime: |
       craftctl default

--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -56,6 +56,7 @@ parts:
         indico==3.2.0 \
         indico-plugin-piwik \
         indico-plugin-storage-s3 \
+        git+https://github.com/bpedersen2/indico-cron-advanced-cleaner \
         python3-saml \
         python-ldap \
         uwsgi \

--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -59,8 +59,8 @@ parts:
         python3-saml \
         python-ldap \
         uwsgi \
-        ./autocreate \
-        ./anonymize
+        ./anonymize \
+        ./autocreate
     override-prime: |
       craftctl default
       /bin/bash -c "mkdir -p --mode=775 srv/indico/{archive,cache,custom,etc,log,tmp}"

--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -60,6 +60,7 @@ parts:
         python-ldap \
         uwsgi \
         ./autocreate
+        ./anonymize
     override-prime: |
       craftctl default
       /bin/bash -c "mkdir -p --mode=775 srv/indico/{archive,cache,custom,etc,log,tmp}"

--- a/src/charm.py
+++ b/src/charm.py
@@ -3,6 +3,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+# pylint: disable=too-many-lines
 """Charm for Indico on kubernetes."""
 import logging
 import os

--- a/src/charm.py
+++ b/src/charm.py
@@ -1018,9 +1018,8 @@ class IndicoOperatorCharm(CharmBase):
             except ExecError as ex:
                 logger.exception("Action anonymize-user failed: %s", ex.stdout)
                 fail_msg = f"Failed to anonymize user {event.params['email']}: {ex.stdout!r}"
-                event.fail(fail_msg)
+                event.fail("Failed to anonymize one or more users, please verify the results.")
                 yield fail_msg
-                return
 
     def _anonymize_user_action(self, event: ActionEvent) -> None:
         """Anonymize user in Indico.

--- a/src/charm.py
+++ b/src/charm.py
@@ -1001,6 +1001,9 @@ class IndicoOperatorCharm(CharmBase):
                 logger.error(
                     "Action anonymize-user failed: cannot connect to the Indico workload container"
                 )
+                self.unit.status = WaitingStatus(
+                    "Waiting to be able to connect to workload container"
+                )
                 return
 
             process = container.exec(

--- a/src/charm.py
+++ b/src/charm.py
@@ -1006,7 +1006,7 @@ class IndicoOperatorCharm(CharmBase):
                 )
                 try:
                     out = process.wait_output()
-                    yield out[0]
+                    yield out[0].replace("\n", "")
                 except ExecError as ex:
                     logger.exception("Action anonymize-user failed: %s", ex.stdout)
                     fail_msg = f"Failed to anonymize user {event.params['email']}: {ex.stdout!r}"
@@ -1035,7 +1035,7 @@ class IndicoOperatorCharm(CharmBase):
         event.set_results(
             {
                 "user": f"{event.params['email']}",
-                "output": (EMAIL_LIST_SEPARATOR.join(output_list), None),
+                "output": EMAIL_LIST_SEPARATOR.join(output_list),
             }
         )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -1024,10 +1024,12 @@ class IndicoOperatorCharm(CharmBase):
             event: Event triggered by the anonymize-user action
         """
         if len(event.params["email"].split(EMAIL_LIST_SEPARATOR)) > EMAIL_LIST_MAX:
-            max_reached_msg = f"List of more than {EMAIL_LIST_MAX} emails are not allowed"
-            fail_msg = f"Failed to anonymize user: {max_reached_msg}"
-            logger.error("Action anonymize-user failed: %s", fail_msg)
-            event.fail(fail_msg)
+            max_reached_msg = (
+                "Failed to anonymize user: "
+                f"List of more than {EMAIL_LIST_MAX} emails are not allowed"
+            )
+            logger.error("Action anonymize-user failed: %s", max_reached_msg)
+            event.fail(max_reached_msg)
             return
         output_list = list(self._execute_anonymize_cmd(event))
         event.set_results(

--- a/src/charm.py
+++ b/src/charm.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 CANONICAL_LDAP_HOST = "ldap.canonical.com"
 CELERY_PROMEXP_PORT = "9808"
 DATABASE_NAME = "indico"
+EMAIL_LIST_MAX = 50
 EMAIL_LIST_SEPARATOR = ","
 INDICO_CUSTOMIZATION_DIR = "/srv/indico/custom"
 NGINX_PROMEXP_PORT = "9113"
@@ -1019,6 +1020,11 @@ class IndicoOperatorCharm(CharmBase):
         Args:
             event: Event triggered by the anonymize-user action
         """
+        if len(event.params["email"].split(EMAIL_LIST_SEPARATOR)) > EMAIL_LIST_MAX:
+            fail_msg = "List of more than 50 emails are not allowed"
+            logger.error("Action anonymize-user failed: %s", fail_msg)
+            event.fail(fail_msg)
+            return
         output_list = []
         try:
             output_list = list(self._execute_anonymize_cmd(event))

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -207,13 +207,11 @@ async def test_saml_auth(
             verify=False,
             timeout=requests_timeout,
         )
-
-        assert hasattr(login_page, "text")
-        logger.info("debug: %s", login_page.text)
-        assert len(login_page.text) > 1
-        csrf_token = re.findall(
+        csrf_token_matches = re.findall(
             "<input type='hidden' name='csrfmiddlewaretoken' value='([^']+)' />", login_page.text
-        )[0]
+        )
+        assert len(csrf_token_matches) > 0
+        csrf_token = csrf_token_matches[0]
         saml_callback = session.post(
             "https://login.staging.ubuntu.com/+login",
             data={
@@ -229,12 +227,11 @@ async def test_saml_auth(
             headers={"Referer": login_page.url},
             timeout=requests_timeout,
         )
-        assert hasattr(saml_callback, "text")
-        logger.info("debug: %s", saml_callback.text)
-        assert len(saml_callback.text) > 1
-        saml_response = re.findall(
+        saml_response_matches = re.findall(
             '<input type="hidden" name="SAMLResponse" value="([^"]+)" />', saml_callback.text
-        )[0]
+        )
+        assert len(saml_response_matches) > 0
+        saml_response = saml_response_matches[0]
         session.post(
             f"https://{host}/multipass/saml/ubuntu/acs",
             data={

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -154,6 +154,8 @@ async def test_anonymize_user(app: Application):
     assert all(word in action_anonymize.results["output"] for word in expected_words)
 
 
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
 @pytest.mark.requires_secrets
 async def test_saml_auth(
     ops_test: OpsTest,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import juju.action
 import pytest
+import pytest_asyncio
 import requests
 import urllib3.exceptions
 from ops.model import ActiveStatus, Application
@@ -106,9 +107,8 @@ async def test_health_checks(app: Application):
         assert stdout.count("0/3") == 1
 
 
-@pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-@pytest.fixture(scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def add_admin(app: Application):
     """
     arrange: given charm in its initial state
@@ -143,7 +143,6 @@ async def test_anonymize_user(app: Application):
     act: run the anonymize-user action
     assert: check the output in the action result
     """
-
     # Application actually does have units
     action_anonymize: juju.action.Action = await app.units[0].run_action(  # type: ignore
         "anonymize-user", email=ADMIN_USER_EMAIL

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -116,8 +116,9 @@ async def add_admin(app: Application):
     assert: check the output in the action result
     """
 
-    # Application actually does have units
-    assert app.units[0]  # type: ignore
+    assert hasattr(app, "units")
+
+    assert app.units[0]
 
     email = ADMIN_USER_EMAIL
     # This is a test password

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,6 +4,7 @@
 
 """Indico charm integration tests."""
 
+import logging
 import re
 import socket
 from unittest.mock import patch
@@ -24,6 +25,8 @@ from charm import (
 )
 
 ADMIN_USER_EMAIL = "sample@email.com"
+
+logger = logging.getLogger()
 
 
 @pytest.mark.asyncio
@@ -223,6 +226,9 @@ async def test_saml_auth(
             headers={"Referer": login_page.url},
             timeout=requests_timeout,
         )
+        assert hasattr(saml_callback, "text")
+        logger.info("debug: %s", saml_callback.text)
+        assert len(saml_callback.text) > 1
         saml_response = re.findall(
             '<input type="hidden" name="SAMLResponse" value="([^"]+)" />', saml_callback.text
         )[0]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -162,6 +162,7 @@ async def test_anonymize_user(app: Application):
     assert action_anonymize.results["user"] == email
     assert f'User with email "{email}" correctly anonymized' in action_anonymize.results["output"]
 
+
 @pytest.mark.requires_secrets
 async def test_saml_auth(
     ops_test: OpsTest,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -211,11 +211,10 @@ async def test_saml_auth(
             "<input type='hidden' name='csrfmiddlewaretoken' value='([^']+)' />", login_page.text
         )
         assert len(csrf_token_matches) > 0
-        csrf_token = csrf_token_matches[0]
         saml_callback = session.post(
             "https://login.staging.ubuntu.com/+login",
             data={
-                "csrfmiddlewaretoken": csrf_token,
+                "csrfmiddlewaretoken": csrf_token_matches[0],
                 "email": saml_email,
                 "user-intentions": "login",
                 "password": saml_password,
@@ -231,12 +230,11 @@ async def test_saml_auth(
             '<input type="hidden" name="SAMLResponse" value="([^"]+)" />', saml_callback.text
         )
         assert len(saml_response_matches) > 0
-        saml_response = saml_response_matches[0]
         session.post(
             f"https://{host}/multipass/saml/ubuntu/acs",
             data={
                 "RelayState": "None",
-                "SAMLResponse": saml_response,
+                "SAMLResponse": saml_response_matches[0],
                 "openid.usernamesecret": "",
             },
             verify=False,
@@ -244,7 +242,7 @@ async def test_saml_auth(
         )
         session.post(
             f"https://{host}/multipass/saml/ubuntu/acs",
-            data={"SAMLResponse": saml_response, "SameSite": "1"},
+            data={"SAMLResponse": saml_response_matches[0], "SameSite": "1"},
             verify=False,
             timeout=requests_timeout,
         )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -118,3 +118,36 @@ async def test_add_admin(app: Application):
     assert action.status == "completed"
     assert action.results["user"] == email
     assert f'Admin with email "{email}" correctly created' in action.results["output"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_anonymize_user(app: Application):
+    """
+    arrange: given charm in its initial state
+    act: create an user and run the anonymize-user action
+    assert: check the output in the action result
+    """
+
+    # Application actually does have units
+    assert app.units[0]  # type: ignore
+
+    email = "anonymize@email.com"
+    # This is a test password
+    password = "somepassword"  # nosec
+
+    # Application actually does have units
+    action_add_admin: juju.action.Action = await app.units[0].run_action(  # type: ignore
+        "add-admin", email=email, password=password
+    )
+    await action_add_admin.wait()
+    assert action_add_admin.status == "completed"
+
+    # Application actually does have units
+    action_anonymize: juju.action.Action = await app.units[0].run_action(  # type: ignore
+        "anonymize-user", email=email
+    )
+    await action_anonymize.wait()
+    assert action_anonymize.status == "completed"
+    assert action_anonymize.results["user"] == email
+    assert f'User with email "{email}" correctly anonymized' in action_anonymize.results["output"]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -208,6 +208,9 @@ async def test_saml_auth(
             timeout=requests_timeout,
         )
 
+        assert hasattr(login_page, "text")
+        logger.info("debug: %s", login_page.text)
+        assert len(login_page.text) > 1
         csrf_token = re.findall(
             "<input type='hidden' name='csrfmiddlewaretoken' value='([^']+)' />", login_page.text
         )[0]

--- a/tests/unit/_patched_charm.py
+++ b/tests/unit/_patched_charm.py
@@ -62,3 +62,5 @@ class _PGSQLPatch:
 
 pgsql_patch = _PGSQLPatch()
 IndicoOperatorCharm = __import__("charm").IndicoOperatorCharm
+EMAIL_LIST_MAX = __import__("charm").EMAIL_LIST_MAX
+EMAIL_LIST_SEPARATOR = __import__("charm").EMAIL_LIST_SEPARATOR

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -361,7 +361,7 @@ class TestActions(TestBase):
         )
 
         # Check if event fail was properly set
-        expected_argument = f"Failed to anonymize user {email}: '{error_msg}'"
+        expected_argument = "Failed to anonymize one or more users, please verify the results."
         # Pylint does not understand that the mock supports this call
         mock_event.fail.assert_called_with(expected_argument)  # pylint: disable=no-member
 

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -248,9 +248,7 @@ class TestActions(TestBase):
             validate_command(email)
 
         # Check if event results was properly set
-        mock_event.set_results.assert_called_with(
-            {"user": f"{emails}", "output": (f"{emails}", None)}
-        )
+        mock_event.set_results.assert_called_with({"user": f"{emails}", "output": f"{emails}"})
 
     @patch.object(Container, "exec")
     def test_anonymize_user(self, mock_exec):
@@ -371,6 +369,6 @@ class TestActions(TestBase):
         mock_event.set_results.assert_called_with(
             {
                 "user": f"{email}",
-                "output": (f"Failed to anonymize user {email}: '{error_msg}'", None),
+                "output": f"Failed to anonymize user {email}: '{error_msg}'",
             }
         )

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -318,7 +318,7 @@ class TestActions(TestBase):
 
         # Set Mock
         email = "sample@email.com"
-        error_msg = "Failed"
+        error_msg = "Execution error"
         expected_cmd = [
             "/usr/local/bin/indico",
             "anonymize",
@@ -330,7 +330,6 @@ class TestActions(TestBase):
         )
         wait_output = MagicMock(side_effect=expected_exception)
         mock_exec.return_value = MagicMock(wait_output=wait_output)
-
         # Set and trigger the event
         mock_event = MagicMock(spec=ActionEvent)
         mock_event.params = {
@@ -352,3 +351,11 @@ class TestActions(TestBase):
         expected_argument = f"Failed to anonymize user {email}: '{error_msg}'"
         # Pylint does not understand that the mock supports this call
         mock_event.fail.assert_called_with(expected_argument)  # pylint: disable=no-member
+
+        # Check if event results was properly set
+        mock_event.set_results.assert_called_with(
+            {
+                "user": f"{email}",
+                "output": (f"Failed to anonymize user {email}: '{error_msg}'", None),
+            }
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -86,6 +86,7 @@ deps =
     mypy
     pep8-naming
     indico_rock/plugins/autocreate
+    indico_rock/plugins/anonymize
     pydocstyle>=2.10
     pylint
     pyproject-flake8<6.0.0
@@ -101,12 +102,13 @@ commands =
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg \
       --skip {toxinidir}/indico_rock/plugins/autocreate/.mypy_cache
+      --skip {toxinidir}/indico_rock/plugins/anonymize/.mypy_cache
     # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]plugins_path} --ignore=W503
     isort --check-only --diff {[vars]plugins_path}
     black --check --diff {[vars]plugins_path}
     mypy {[vars]plugins_path}
-    pylint {[vars]plugins_path} --ignore-paths {[vars]plugins_path}/autocreate/build
+    pylint {[vars]plugins_path} --ignore-paths indico_rock/plugins/autocreate/build/,indico_rock/plugins/anonymize/build/
 
 [testenv:unit]
 description = Run unit tests

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ commands =
     isort --check-only --diff {[vars]plugins_path}
     black --check --diff {[vars]plugins_path}
     mypy {[vars]plugins_path}
-    pylint {[vars]plugins_path} --ignore-paths indico_rock/plugins/autocreate/build/,indico_rock/plugins/anonymize/build/
+    pylint {[vars]plugins_path} --ignore-paths {[vars]plugins_path}/autocreate/build,{[vars]plugins_path}/anonymize/build
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
Add anonymize-user action by using the same idea of adding an admin user: extends the CLI to anonymize a user using the e-mail list separated by a comma as a parameter.

Fields affected:
User data:
- ['affiliation', 'email', 'secondary_emails', ] = ""
- ['favorite_users', 'favorite_categories', 'identities'] = empty
- ['old_api_keys',] = empty
- ['first_name', 'last_name', 'phone', 'address',] = hash

Event Registration data:
- All text/textarea fields = hash
- Email = hash + "@invalid.invalid"
- Phone = (+00) 0000000
- First name = hash
- Last name = hash
- Email = hash

Reference:
https://github.com/bpedersen2/indico-cron-advanced-cleaner/