### PR TITLE
[DO NOT MERGE] Isd 420 investigate GitHub workflow caching

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@ISD-420-investigate-github-workflow-caching
     secrets: inherit
     with:
       chaos-app-label: app.kubernetes.io/name=indico

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/test.yaml@ISD-420-investigate-github-workflow-caching
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@ISD-420-investigate-github-workflow-caching
     secrets: inherit
     with:
       chaos-app-label: app.kubernetes.io/name=indico

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -2,6 +2,9 @@ name: Integration tests
 
 on:
   pull_request:
+  push:
+    branches:
+      - ISD-420-investigate-github-workflow-caching
 
 jobs:
   integration-tests:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ name: Tests
 
 on:
   pull_request:
+  push:
+    branches:
+      - ISD-420-investigate-github-workflow-caching
 
 jobs:
   unit-tests:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   unit-tests:
-    uses: canonical/operator-workflows/.github/workflows/test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@ISD-420-investigate-github-workflow-caching
     secrets: inherit
   plugins-test:
     name: Specific test for the plugin

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@ISD-420-investigate-github-workflow-caching
     secrets: inherit
   plugins-test:
-    name: Specific test for the plugins
+    name: Specific test for the plugin
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@ISD-420-investigate-github-workflow-caching
     secrets: inherit
   plugins-test:
-    name: Specific test for the plugin
+    name: Specific test for the plugins
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,7 @@
 """Fixtures for Indico charm integration tests."""
 
 import asyncio
+import glob
 from pathlib import Path
 from typing import Dict
 
@@ -92,7 +93,11 @@ async def app(
         "indico-nginx-image": pytestconfig.getoption("--indico-nginx-image"),
     }
     resources.update(prometheus_exporter_images)
-    charm = await ops_test.build_charm(".")
+    cached = next(glob.glob('**/*.charm', recursive=True))
+    if cached is not None:
+        charm = Path(cached)
+    else:
+        charm = await ops_test.build_charm(".")
     application = await ops_test.model.deploy(
         charm, resources=resources, application_name=app_name, series="focal"
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -96,7 +96,7 @@ async def app(
     cached = glob.glob("**/*.charm", recursive=True)
     print(f"found {cached} charms")
     if len(cached) >= 1:
-        charm = Path(cached[0])
+        charm = f"./{Path(cached[0])}"
     else:
         charm = await ops_test.build_charm(".")
     application = await ops_test.model.deploy(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,6 +94,7 @@ async def app(
     }
     resources.update(prometheus_exporter_images)
     cached = glob.glob("**/*.charm", recursive=True)
+    print(f"found {cached} charms")
     if len(cached) >= 1:
         charm = Path(cached[0])
     else:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,8 +94,8 @@ async def app(
     }
     resources.update(prometheus_exporter_images)
     cached = next(glob.glob('**/*.charm', recursive=True))
-    if cached is not None:
-        charm = Path(cached)
+    if len(cached) >= 1:
+        charm = Path(cached[0])
     else:
         charm = await ops_test.build_charm(".")
     application = await ops_test.model.deploy(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -93,7 +93,7 @@ async def app(
         "indico-nginx-image": pytestconfig.getoption("--indico-nginx-image"),
     }
     resources.update(prometheus_exporter_images)
-    cached = next(glob.glob('**/*.charm', recursive=True))
+    cached = glob.glob("**/*.charm", recursive=True)
     if len(cached) >= 1:
         charm = Path(cached[0])
     else:


### PR DESCRIPTION
This is a POC of using Github caches and demonstrates how to change the integration test so that it can benefit from the cache and use an already built charm during the integration test. The pytest-operator logic is to always build a charm, run the tests and clean up afterwards, so that logic is necessary on the charm repo level. The accompanying cache code in operator-workflows is at https://github.com/canonical/operator-workflows/pull/109