### PR TITLE
docs(ISD-525): Documentation refactoring

### DIFF
--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -1,4 +1,4 @@
-# Charm Architecture
+# Charm architecture
 
 At its core, [Indico](https://getindico.io/) is a [Flask](https://flask.palletsprojects.com/) application that integrates with [PostgreSQL](https://www.postgresql.org/), [Redis](https://redis.io/), and [Celery](https://docs.celeryq.dev/en/stable/).
 
@@ -52,7 +52,7 @@ The Celery is used to process tasks asynchronously created by the Indico applica
 
 The Celery container runs the same workload as the Indico container, as defined in the [Indico dockerfile in the charm repository](https://github.com/canonical/indico-operator/blob/main/indico.Dockerfile).
 
-### NGINX Prometheus Exporter
+### NGINX Prometheus exporter
 
 This container runs the `nginx/nginx-prometheus-exporter` image.
 
@@ -60,7 +60,7 @@ The `NGINX Prometheus Exporter` is started with `-nginx.scrape-uri=http://localh
 
 This has been configured in the NGINX container to return NGINX's [stub_status](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html). The exporter listens on port `9113` and metrics about web traffic to the pod can be scraped by Prometheus there.
 
-### StatsD Prometheus Exporter
+### StatsD Prometheus exporter
 
 This container runs the `prom/statsd-exporter` image.
 
@@ -69,7 +69,7 @@ The `StatsD Prometheus Exporter` listens on ports:
 - `9125`: UDP address on which to receive statsd metric.
 - `9102`: expose the web interface and generated Prometheus metrics. The metrics can be scraped by Prometheus here.
 
-### Celery Prometheus Exporter
+### Celery Prometheus exporter
 
 This container runs the `danihodovic/celery-exporter` image.
 
@@ -84,7 +84,7 @@ The `Celery Prometheus Exporter` listens on port `9808` and metrics about Indico
 
 The Grafana dashboard is the same available [here](https://grafana.com/grafana/dashboards/17508-celery-tasks-by-task/).
 
-## Docker Images
+## Docker images
 
 The images defined in [NGINX dockerfile](https://github.com/canonical/indico-operator/blob/main/indico-nginx.Dockerfile) and [Indico dockerfile](https://github.com/canonical/indico-operator/blob/main/indico.Dockerfile) in the charm repository are published to [Charmhub](https://charmhub.io/), the official repository of charms.
 
@@ -121,7 +121,7 @@ Redis is an open-source in-memory data structure store used here as two independ
 1. Cache backend: Copies of frequently accessed data are stored and used if satisfy the request. Otherwise, the application will handle it. This configuration helps to reduce the number of queries and improve response latency.
 2. Message broker: Used for communication between Indico and the Celery background workers.
 
-## Juju Events
+## Juju events
 
 Accordingly to the [Juju SDK](https://juju.is/docs/sdk/event): "an event is a data structure that encapsulates part of the execution context of a charm".
 
@@ -142,7 +142,7 @@ Action: Same as config_changed.
 7. [refresh_external_resources_action](https://charmhub.io/indico/actions): fired when refresh-external-resources action is executed.
 Action: Pull changes from the customization repository, reload uWSGI and upgrade the external plugins.
 
-## Charm Code Overview
+## Charm code overview
 
 The `src/charm.py` is the default entry point for a charm and has the IndicoOperatorCharm Python class which inherits from CharmBase.
 

--- a/docs/how-to/configure-a-proxy.md
+++ b/docs/how-to/configure-a-proxy.md
@@ -1,4 +1,4 @@
-# How to configure proxy
+# How to configure a proxy
 
 This charm supports several operations that require access to external resources, such as customization or plugins installation, so your environment may not be able to reach those URLs unless through a proxy. The proxy can be configured via two configuration options `http_proxy` for HTTP requests, and `https_proxy` for HTTPS request.
 

--- a/docs/how-to/configure-external-hostname.md
+++ b/docs/how-to/configure-external-hostname.md
@@ -1,4 +1,4 @@
-# Configure the external hostname
+# How to configure external hostname
 
 This charm exposes the `site_url` configuration option to specify the external hostname of the application.
 

--- a/docs/how-to/configure-ldap.md
+++ b/docs/how-to/configure-ldap.md
@@ -1,4 +1,4 @@
-# LDAP configuration
+# How to configure LDAP
 
 To configure Indico's LDAP integration you'll have to set `ldap_host` with the URL for your LDAP server by running `juju config [charm_name] ldap_host=[value]` and `ldap_password` with its credentials `juju config [charm_name] ldap_password=[value]`.
 

--- a/docs/how-to/configure-proxy.md
+++ b/docs/how-to/configure-proxy.md
@@ -1,4 +1,4 @@
-# Proxy configuration
+# How to configure proxy
 
 This charm supports several operations that require access to external resources, such as customization or plugins installation, so your environment may not be able to reach those URLs unless through a proxy. The proxy can be configured via two configuration options `http_proxy` for HTTP requests, and `https_proxy` for HTTPS request.
 

--- a/docs/how-to/configure-s3.md
+++ b/docs/how-to/configure-s3.md
@@ -1,4 +1,4 @@
-# S3 configuration
+# How to configure S3
 
 An S3 bucket can be leveraged to serve the static content uploaded to Indico, potentially improving performance. Moreover, it is required when scaling the charm to serve the uploaded files. To configure it to set the appropriate connection parameters in `s3_storage` for your existing bucket `juju config [charm_name] s3_storage=[value]`.
 

--- a/docs/how-to/configure-saml.md
+++ b/docs/how-to/configure-saml.md
@@ -1,4 +1,4 @@
-# SAML configuration
+# How to configure SAML
 
 To configure Indico's SAML integration you'll have to set `saml_target_url` with the URL for your SAML server by running `juju config [charm_name] saml_target_url=[value]`.
 

--- a/docs/how-to/configure-smtp.md
+++ b/docs/how-to/configure-smtp.md
@@ -1,4 +1,4 @@
-# SMTP configuration
+# How to configure SMTP
 
 To configure Indico's SMTP you'll have to set the following configuration options with the appropriate values for your SMTP server by running `juju config [charm_name] [configuration]=[value]`.
 

--- a/docs/how-to/configure-the-external-hostname.md
+++ b/docs/how-to/configure-the-external-hostname.md
@@ -1,4 +1,4 @@
-# How to configure external hostname
+# How to configure the external hostname
 
 This charm exposes the `site_url` configuration option to specify the external hostname of the application.
 

--- a/docs/how-to/contribute.md
+++ b/docs/how-to/contribute.md
@@ -1,4 +1,4 @@
-# Contributing
+# How to contribute
 
 ## Overview
 
@@ -69,7 +69,7 @@ The following commands push the required images into the registry:
 juju add-model indico-dev
 # Enable DEBUG logging
 juju model-config logging-config="<root>=INFO;unit=DEBUG"
-# Deploy the charm (Assuming you're on amd64)
+# Deploy the charm (assuming you're on amd64)
 juju deploy ./indico_ubuntu-20.04-amd64.charm \
   --resource indico-image=localhost:32000/indico:latest \
   --resource indico-nginx-image=localhost:32000/indico-nginx:latest \

--- a/docs/how-to/customize-theme.md
+++ b/docs/how-to/customize-theme.md
@@ -1,4 +1,4 @@
-# Theme customization
+# How to customize theme
 
 This charm supports providing static source files for customizing Indico look and feel. Details on how those files should look like can be consulted in [Indico's official documentation](https://docs.getindico.io/en/stable/config/settings/#customization).
 

--- a/docs/how-to/install-plugins.md
+++ b/docs/how-to/install-plugins.md
@@ -1,4 +1,4 @@
-# Install plugins
+# How to install plugins
 
 This charm supports installing both official and custom plugins for Indico, from pypi and from a git repositories.
 

--- a/docs/reference/theme-customization.md
+++ b/docs/reference/theme-customization.md
@@ -1,4 +1,4 @@
-# Theme Customization
+# Theme customization
 
 Indico offers a framework for customizing the look and feel of your Indico installation. See more information in [Customization](https://docs.getindico.io/en/latest/config/settings/#customization).
 

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -1,6 +1,6 @@
-# Quick Guide
+# Quick guide
 
-## What you’ll learn
+## What you’ll do
 
 - Deploy the [Indico charm](https://charmhub.io/indico).
 - Relate to [the Redis K8s charm](https://charmhub.io/redis-k8s) and [the PostgreSQL K8s charm](https://charmhub.io/postgresql-k8s).
@@ -46,7 +46,7 @@ indico/0*                 waiting   idle   10.1.74.70             Waiting for re
 
 This means that Indico charm isn't integrated with Redis yet.
 
-### Relate to the Redis K8s charm the PostgreSQL K8s charm
+### Relate to the Redis k8s charm the PostgreSQL k8s charm
 
 Provide integration between Indico and Redis by running the following [`juju relate`](https://juju.is/docs/olm/juju-relate) commands:
 
@@ -80,7 +80,7 @@ indico                 3.2                           active      1  indico      
 
 The deployment finishes when the status shows "Active".
 
-### Relate to Ingress by using NGINX Ingress Integrator
+### Relate to Ingress by using NGINX Ingress Integrator charm
 
 The NGINX Ingress Integrator charm can deploy and manage external access to HTTP/HTTPS services in a Kubernetes cluster.
 


### PR DESCRIPTION
* Rename tutorials to tutorial
* Rename how-to-guides to how-to
* Rename submenus to action ("how-to/configure-ldap.md")
* Rename how-to titles
* Capitalization - First letter of each heading only (European style)