### PR TITLE
Fix integration tests on release

### DIFF
--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -19,4 +19,5 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@main
     secrets: inherit
     with:
+      extra-arguments: -m "not (requires_secrets)"
       trivy-image-config: "trivy.yaml"


### PR DESCRIPTION
Skip integration tests requiring secrets on the release pipeline