### PR TITLE
Fix incorrect URL in the documentation.

### DIFF
--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -61,4 +61,4 @@ to the dashboard can be made but will not be persisted upon restart/redeployment
 Grafana-Prometheus relate command: `juju relate grafana-k8s:grafana-source prometheus-k8s:grafana-source`  
 Grafana-dashboard relate command: `juju relate wordpress-k8s grafana-dashboard`
 
-See more information in [Charm Architecture](https://charmhub.io/indico/docs/charm-architecture).
+See more information in [Charm Architecture](https://charmhub.io/indico/docs/explanation-charm-architecture).

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -18,7 +18,7 @@ For more information about how to install Juju, see [Get started with Juju](http
 
 ### Deploy the Indico charm
 
-Since Indico requires connections to PostgreSQL and Redis, you'll deploy them too. For more information, see [Charm Architecture](https://charmhub.io/indico/docs/charm-architecture).
+Since Indico requires connections to PostgreSQL and Redis, you'll deploy them too. For more information, see [Charm Architecture](https://charmhub.io/indico/docs/explanation-charm-architecture).
 
 Redis is deployed twice because one is for the broker and the other for the cache. To do this, the `juju deploy` command accepts an extra argument with the custom application name. See more details in [Override the name of a deployed application](https://juju.is/docs/olm/deploy-a-charm-from-charmhub#heading--override-the-name-of-a-deployed-application).
 


### PR DESCRIPTION
Fix the incorrect URL https://charmhub.io/indico/docs/charm-architecture by changing it to https://charmhub.io/indico/docs/explanation-charm-architecture.