### PR TITLE
Adapt integration tests to reuse the packed charm

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,7 +12,7 @@ jobs:
       chaos-enabled: true
       chaos-experiments: pod-delete
       extra-arguments: -m "not (requires_secrets)"
-      load-test-enabled: true
+      load-test-enabled: false
       load-test-run-args: "-e LOAD_TEST_HOST=localhost"
       zap-before-command: "curl -H \"Host: indico.local\" http://localhost/bootstrap --data-raw 'csrf_token=00000000-0000-0000-0000-000000000000&first_name=admin&last_name=admin&email=admin%40admin.com&username=admin&password=lunarlobster&confirm_password=lunarlobster&affiliation=Canonical'"
       zap-enabled: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ def pytest_addoption(parser):
     Args:
         parser: Pytest parser.
     """
+    parser.addoption("--charm-file", action="store")
     parser.addoption("--indico-image", action="store")
     parser.addoption("--indico-nginx-image", action="store")
     parser.addoption("--saml-email", action="store")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,7 +94,7 @@ async def app(
     resources.update(prometheus_exporter_images)
     charm = pytestconfig.getoption("--charm-file")
     application = await ops_test.model.deploy(
-        charm,
+        f"./{charm}",
         resources=resources,
         application_name=app_name,
         series="focal",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -92,7 +92,7 @@ async def app(
         "indico-nginx-image": pytestconfig.getoption("--indico-nginx-image"),
     }
     resources.update(prometheus_exporter_images)
-    charm = await ops_test.build_charm(".")
+    charm = pytestconfig.getoption("--charm-file")
     application = await ops_test.model.deploy(
         charm,
         resources=resources,


### PR DESCRIPTION
Adapt the integration tests to reuse the exisintg charm artifact as per https://github.com/canonical/operator-workflows/pull/162
Load test are disabled due to their flakiness. There's a scheduled weekly execution already