### PR TITLE
Use SAML groups identity provider

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -3,3 +3,7 @@
 Indico provides many plugins that can be used to extend functionalities without the need to change the Indico core. See more information in [Extending Indico with plugins](https://docs.getindico.io/en/latest/plugins/).
 
 You can configure additional plugins using the [`external_plugins`](https://charmhub.io/indico/configure#external_plugins) configuration option.
+
+There is a special treatment for the [Flask-Multipass-SAML-Groups](https://github.com/canonical/flask-multipass-saml-groups/) plugin: 
+When this plugin is configured, the charm will automatically configure Indico to use the provided custom Indico Identity Provider `saml_groups`
+if `saml_target_url` is configured.

--- a/src/charm.py
+++ b/src/charm.py
@@ -42,6 +42,8 @@ PORT = 8080
 STATSD_PROMEXP_PORT = "9102"
 UBUNTU_SAML_URL = "https://login.ubuntu.com/saml/"
 STAGING_UBUNTU_SAML_URL = "https://login.staging.ubuntu.com/saml/"
+SAML_GROUPS_PLUGIN_NAME = "saml_groups"
+
 UWSGI_TOUCH_RELOAD = "/srv/indico/indico.wsgi"
 
 pgsql = ops.lib.use("pgsql", 1, "postgresql-charmers@lists.launchpad.net")
@@ -692,7 +694,9 @@ class IndicoOperatorCharm(CharmBase):
             env_config["INDICO_AUTH_PROVIDERS"] = str(auth_providers)
             identity_providers = {
                 "ubuntu": {
-                    "type": "saml",
+                    "type": (
+                        "saml_groups" if SAML_GROUPS_PLUGIN_NAME in available_plugins else "saml"
+                    ),
                     "trusted_email": True,
                     "mapping": {
                         "user_name": "username",


### PR DESCRIPTION
Use the identity provider from the [Flask-Multipass-SAML-Groups](https://github.com/canonical/flask-multipass-saml-groups) plugin if it has been configured.