### PR TITLE
Update maintainer to be a URL including scheme so charmhub upload can work

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,7 +27,7 @@ description: |
 docs: https://discourse.charmhub.io/t/indico-documentation-overview/7571
 issues: https://github.com/canonical/indico-operator/issues
 maintainers:
-  - launchpad.net/~canonical-is-devops
+  - https://launchpad.net/~canonical-is-devops
 source: https://github.com/canonical/indico-operator
 assumes:
   - k8s-api


### PR DESCRIPTION
Charmhub requires maintainer to be either a `mailto:` URL or include the `http{,s}` scheme. Update so uploads can proceed.