### PR TITLE
Re-Add CE_ACCEPT_CONTENT to indico env

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -582,6 +582,7 @@ class IndicoOperatorCharm(CharmBase):
         env_config = {
             "ATTACHMENT_STORAGE": "default",
             "CELERY_BROKER": self._get_celery_backend(),
+            "CE_ACCEPT_CONTENT": "json,pickle",
             "CUSTOMIZATION_DEBUG": self.config["customization_debug"],
             "ENABLE_ROOMBOOKING": self.config["enable_roombooking"],
             "INDICO_AUTH_PROVIDERS": str({}),


### PR DESCRIPTION
Follow-up to https://github.com/canonical/indico-operator/pull/291 , the environment variable has to be set to allow proper serialisation (see `docs/explanation/charm-architecture.md`), but had been removed in https://github.com/canonical/indico-operator/pull/291/files#diff-b9ed39bbc9c0387bd3e07da31d13373745534a1cd723d3e292c73496b12e307cL397