### PR TITLE
Switch to edge runners

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,9 @@ jobs:
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
+    with:
+      self-hosted-runner: true
+      self-hosted-runner-label: "edge"
   plugins-test:
     name: Specific test for the plugin
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Switch to using edge self-hosted runners

### Rationale

So that we use the edge runners in our team before they are rolled out more broadly

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->