### PR TITLE
Retrieve SMTP config from SMTP integrator

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,4 +21,3 @@ jobs:
       zap-rules-file-name: "zap_rules.tsv"
       trivy-fs-enabled: true
       trivy-image-config: "trivy.yaml"
-      tmate-debug: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,3 +21,4 @@ jobs:
       zap-rules-file-name: "zap_rules.tsv"
       trivy-fs-enabled: true
       trivy-image-config: "trivy.yaml"
+      tmate-debug: true

--- a/config.yaml
+++ b/config.yaml
@@ -38,26 +38,6 @@ options:
     type: string
     description: URL through which Indico is accessed by users.
     default: ''
-  smtp_login:
-    type: string
-    description: The username to send if the SMTP server requires authentication.
-    default: ''
-  smtp_password:
-    type: string
-    description: The password to send if the SMTP server requires authentication.
-    default: ''
-  smtp_port:
-    type: int
-    description: The port of the SMTP server used for sending emails.
-    default: 25
-  smtp_server:
-    type: string
-    description: The hostname of the SMTP server used for sending emails.
-    default: ''
-  smtp_use_tls:
-    type: boolean
-    description: If enabled, STARTTLS will be used to use an encrypted SMTP connection.
-    default: true
   s3_storage:
     type: string
     description: Comma separated list of parameters to connect to an S3 bucket as in 's3:bucket=my-indico-test-bucket,access_key=12345,secret_key=topsecret'. Details on the available options can be found at https://github.com/indico/indico-plugins/blob/master/storage_s3/README.md#available-config-options

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -163,7 +163,7 @@ Take, for example, when a configuration is changed by using the CLI.
 
 1. User runs the command
 ```bash
-juju config smtp_login=user1
+juju config indico_no_reply_email=sample@domain.com
 ```
 2. A `config-changed` event is emitted
 3. In the `__init__` method is defined how to handle this event like this:

--- a/docs/how-to/configure-smtp.md
+++ b/docs/how-to/configure-smtp.md
@@ -1,9 +1,0 @@
-# How to configure SMTP
-
-To configure Indico's SMTP you'll have to set the following configuration options with the appropriate values for your SMTP server by running `juju config [charm_name] [configuration]=[value]`.
-
-Set `smtp_server`to the SMTP server IP or hostname, `smtp_port` for the SMTP sever port if different from the default. If authentication is needed, the credentials can be set with `smtp_login`and `smtp_password`. Note that TLS can be turned on and off with `smtp_use_tls`.
-
-This charm exposes the appropriate configuration to modify the sender address for the emails sent by Indico. For emails you do not with the users to reply to, the sender can be set with `indico_no_reply_email`. The public support emails show in the 'Contact' page can be set via `indico_public_support_email` and the technical support email, via `indico_support_email`.
-
-For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/indico/configure).

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,6 @@ If there's a particular area of documentation that you'd like to see that's miss
 | 2 | how-to-configure-a-proxy | [Configure a proxy](/t/indico-docs-how-to-configure-a-proxy/8678) |
 | 2 | how-to-configure-s3 | [Configure S3](/t/indico-docs-how-to-configure-s3/8680) |
 | 2 | how-to-configure-saml | [Configure SAML](/t/indico-docs-how-to-configure-saml/8664) |
-| 2 | how-to-configure-smtp | [Configure SMTP](/t/indico-docs-how-to-configure-smtp/8666) |
 | 2 | how-to-configure-the-external-hostname | [Configure the external hostname](/t/indico-docs-how-to-configure-the-external-hostname/8660) |
 | 2 | how-to-contribute | [Contribute](/t/indico-docs-how-to-contribute/7561) |
 | 2 | how-to-customize-theme | [Customize theme](/t/indico-docs-how-to-customize-theme/8682) |

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -51,7 +51,7 @@ a `SmtpRelationData` data object.
 """
 
 # The unique Charmhub library identifier, never change it
-LIBID = "018a12e798714b69829be1e9a5c481a5"
+LIBID = "09583c2f9c1d4c0f9a40244cfc20b0c2"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -58,12 +58,12 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 # pylint: disable=wrong-import-position
 import logging
 from enum import Enum
-from typing import Optional
+from typing import Dict, List, Optional
 
 import ops
 from pydantic import BaseModel, Field, ValidationError
@@ -125,7 +125,7 @@ class SmtpRelationData(BaseModel):
     transport_security: TransportSecurity
     domain: Optional[str]
 
-    def to_relation_data(self) -> dict[str, str]:
+    def to_relation_data(self) -> Dict[str, str]:
         """Convert an instance of SmtpRelationData to the relation representation.
 
         Returns:
@@ -306,7 +306,7 @@ class SmtpProvides(ops.Object):
         self.relation_name = relation_name
 
     @property
-    def relations(self) -> list[ops.Relation]:
+    def relations(self) -> List[ops.Relation]:
         """The list of Relation instances associated with this relation_name.
 
         Returns:

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -58,7 +58,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 # pylint: disable=wrong-import-position
 import logging
@@ -251,7 +251,6 @@ class SmtpRequires(ops.Object):
             SmtpRelationData: the relation data.
         """
         relation = self.model.get_relation(self.relation_name)
-        assert relation
         return self._get_relation_data_from_relation(relation) if relation else None
 
     def _get_relation_data_from_relation(self, relation: ops.Relation) -> SmtpRelationData:

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -58,7 +58,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 1
 
 # pylint: disable=wrong-import-position
 import logging
@@ -145,6 +145,7 @@ class SmtpRelationData(BaseModel):
             result["password"] = self.password
         if self.password_id:
             result["password_id"] = self.password_id
+        logging.error(result)
         return result
 
 
@@ -321,4 +322,5 @@ class SmtpProvides(ops.Object):
             relation: the relation for which to update the data.
             smtp_data: a SmtpRelationData instance wrapping the data to be updated.
         """
+        logging.error(smtp_data.to_relation_data())
         relation.data[self.charm.model.app].update(smtp_data.to_relation_data())

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -1,0 +1,324 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache2.0. See LICENSE file in charm source for details.
+
+"""Library to manage the integration with the SMTP Integrator charm.
+
+This library contains the Requires and Provides classes for handling the integration
+between an application and a charm providing the `smtp` and `smtp-legacy` integrations.
+If the requirer charm supports secrets, the preferred approach is to use the `smtp`
+relation to leverage them.
+This library also contains a `SmtpRelationData` class to wrap the SMTP data that will
+be shared via the integration.
+
+### Requirer Charm
+
+```python
+
+from charms.smtp_integrator.v0 import SmtpDataAvailableEvent, SmtpRequires
+
+class SmtpRequirerCharm(ops.CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.smtp = smtp.SmtpRequires(self)
+        self.framework.observe(self.smtp.on.smtp_data_available, self._handler)
+        ...
+
+    def _handler(self, events: SmtpDataAvailableEvent) -> None:
+        ...
+
+```
+
+As shown above, the library provides a custom event to handle the scenario in
+which new SMTP data has been added or updated.
+
+### Provider Charm
+
+Following the previous example, this is an example of the provider charm.
+
+```python
+from charms.smtp_integrator.v0 import SmtpDataAvailableEvent, SmtpProvides
+
+class SmtpProviderCharm(ops.CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.smtp = SmtpProvides(self)
+        ...
+
+```
+The SmtpProvides object wraps the list of relations into a `relations` property
+and provides an `update_relation_data` method to update the relation data by passing
+a `SmtpRelationData` data object.
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "018a12e798714b69829be1e9a5c481a5"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 3
+
+# pylint: disable=wrong-import-position
+import logging
+from enum import Enum
+from typing import Optional
+
+import ops
+from pydantic import BaseModel, Field, ValidationError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "smtp"
+LEGACY_RELATION_NAME = "smtp-legacy"
+
+
+class TransportSecurity(str, Enum):
+    """Represent the transport security values.
+
+    Attributes:
+        NONE: none
+        STARTTLS: starttls
+        TLS: tls
+    """
+
+    NONE = "none"
+    STARTTLS = "starttls"
+    TLS = "tls"
+
+
+class AuthType(str, Enum):
+    """Represent the auth type values.
+
+    Attributes:
+        NONE: none
+        NOT_PROVIDED: not_provided
+        PLAIN: plain
+    """
+
+    NONE = "none"
+    NOT_PROVIDED = "not_provided"
+    PLAIN = "plain"
+
+
+class SmtpRelationData(BaseModel):
+    """Represent the relation data.
+
+    Attributes:
+        host: The hostname or IP address of the outgoing SMTP relay.
+        port: The port of the outgoing SMTP relay.
+        user: The SMTP AUTH user to use for the outgoing SMTP relay.
+        password: The SMTP AUTH password to use for the outgoing SMTP relay.
+        password_id: The secret ID where the SMTP AUTH password for the SMTP relay is stored.
+        auth_type: The type used to authenticate with the SMTP relay.
+        transport_security: The security protocol to use for the outgoing SMTP relay.
+        domain: The domain used by the sent emails from SMTP relay.
+    """
+
+    host: str = Field(..., min_length=1)
+    port: int = Field(None, ge=1, le=65536)
+    user: Optional[str]
+    password: Optional[str]
+    password_id: Optional[str]
+    auth_type: AuthType
+    transport_security: TransportSecurity
+    domain: Optional[str]
+
+    def to_relation_data(self) -> dict[str, str]:
+        """Convert an instance of SmtpRelationData to the relation representation.
+
+        Returns:
+            Dict containing the representation.
+        """
+        result = {
+            "host": str(self.host),
+            "port": str(self.port),
+            "auth_type": self.auth_type.value,
+            "transport_security": self.transport_security.value,
+        }
+        if self.domain:
+            result["domain"] = self.domain
+        if self.user:
+            result["user"] = self.user
+        if self.password:
+            result["password"] = self.password
+        if self.password_id:
+            result["password_id"] = self.password_id
+        return result
+
+
+class SmtpDataAvailableEvent(ops.RelationEvent):
+    """Smtp event emitted when relation data has changed.
+
+    Attributes:
+        host: The hostname or IP address of the outgoing SMTP relay.
+        port: The port of the outgoing SMTP relay.
+        user: The SMTP AUTH user to use for the outgoing SMTP relay.
+        password: The SMTP AUTH password to use for the outgoing SMTP relay.
+        password_id: The secret ID where the SMTP AUTH password for the SMTP relay is stored.
+        auth_type: The type used to authenticate with the SMTP relay.
+        transport_security: The security protocol to use for the outgoing SMTP relay.
+        domain: The domain used by the sent emails from SMTP relay.
+    """
+
+    @property
+    def host(self) -> str:
+        """Fetch the SMTP host from the relation."""
+        assert self.relation.app
+        return self.relation.data[self.relation.app].get("host")
+
+    @property
+    def port(self) -> int:
+        """Fetch the SMTP port from the relation."""
+        assert self.relation.app
+        return int(self.relation.data[self.relation.app].get("port"))
+
+    @property
+    def user(self) -> str:
+        """Fetch the SMTP user from the relation."""
+        assert self.relation.app
+        return self.relation.data[self.relation.app].get("user")
+
+    @property
+    def password(self) -> str:
+        """Fetch the SMTP password from the relation."""
+        assert self.relation.app
+        return self.relation.data[self.relation.app].get("password")
+
+    @property
+    def password_id(self) -> str:
+        """Fetch the SMTP password from the relation."""
+        assert self.relation.app
+        return self.relation.data[self.relation.app].get("password_id")
+
+    @property
+    def auth_type(self) -> AuthType:
+        """Fetch the SMTP auth type from the relation."""
+        assert self.relation.app
+        return AuthType(self.relation.data[self.relation.app].get("auth_type"))
+
+    @property
+    def transport_security(self) -> TransportSecurity:
+        """Fetch the SMTP transport security protocol from the relation."""
+        assert self.relation.app
+        return TransportSecurity(self.relation.data[self.relation.app].get("transport_security"))
+
+    @property
+    def domain(self) -> str:
+        """Fetch the SMTP domain from the relation."""
+        assert self.relation.app
+        return self.relation.data[self.relation.app].get("domain")
+
+
+class SmtpRequiresEvents(ops.CharmEvents):
+    """SMTP events.
+
+    This class defines the events that a SMTP requirer can emit.
+
+    Attributes:
+        smtp_data_available: the SmtpDataAvailableEvent.
+    """
+
+    smtp_data_available = ops.EventSource(SmtpDataAvailableEvent)
+
+
+class SmtpRequires(ops.Object):
+    """Requirer side of the SMTP relation.
+
+    Attributes:
+        on: events the provider can emit.
+    """
+
+    on = SmtpRequiresEvents()
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        """Construct.
+
+        Args:
+            charm: the provider charm.
+            relation_name: the relation name.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def _is_relation_data_valid(self, relation: ops.Relation) -> bool:
+        """Validate the relation data.
+
+        Args:
+            relation: the relation to validate.
+
+        Returns:
+            true: if the relation data is valid.
+        """
+        try:
+            assert relation.app
+            relation_data = relation.data[relation.app]
+            _ = SmtpRelationData(
+                host=relation_data.get("host"),
+                port=relation_data.get("port"),
+                user=relation_data.get("user"),
+                password=relation_data.get("password"),
+                password_id=relation_data.get("password_id"),
+                auth_type=relation_data.get("auth_type"),
+                transport_security=relation_data.get("transport_security"),
+                domain=relation_data.get("domain"),
+            )
+            return True
+        except ValidationError:
+            return False
+
+    def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed.
+
+        Args:
+            event: event triggering this handler.
+        """
+        assert event.relation.app
+        relation_data = event.relation.data[event.relation.app]
+        if relation_data:
+            if relation_data["auth_type"] == AuthType.NONE.value:
+                logger.warning('Insecure setting: auth_type has a value "none"')
+            if relation_data["transport_security"] == TransportSecurity.NONE.value:
+                logger.warning('Insecure setting: transport_security has value "none"')
+            if self._is_relation_data_valid(event.relation):
+                self.on.smtp_data_available.emit(event.relation, app=event.app, unit=event.unit)
+
+
+class SmtpProvides(ops.Object):
+    """Provider side of the SMTP relation.
+
+    Attributes:
+        relations: list of charm relations.
+    """
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        """Construct.
+
+        Args:
+            charm: the provider charm.
+            relation_name: the relation name.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    @property
+    def relations(self) -> list[ops.Relation]:
+        """The list of Relation instances associated with this relation_name.
+
+        Returns:
+            List of relations to this charm.
+        """
+        return list(self.model.relations[self.relation_name])
+
+    def update_relation_data(self, relation: ops.Relation, smtp_data: SmtpRelationData) -> None:
+        """Update the relation data.
+
+        Args:
+            relation: the relation for which to update the data.
+            smtp_data: a SmtpRelationData instance wrapping the data to be updated.
+        """
+        relation.data[self.charm.model.app].update(smtp_data.to_relation_data())

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -145,7 +145,6 @@ class SmtpRelationData(BaseModel):
             result["password"] = self.password
         if self.password_id:
             result["password_id"] = self.password_id
-        logging.error(result)
         return result
 
 
@@ -322,5 +321,4 @@ class SmtpProvides(ops.Object):
             relation: the relation for which to update the data.
             smtp_data: a SmtpRelationData instance wrapping the data to be updated.
         """
-        logging.error(smtp_data.to_relation_data())
         relation.data[self.charm.model.app].update(smtp_data.to_relation_data())

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -63,6 +63,9 @@ requires:
   redis:
     interface: redis
     limit: 2
+  smtp-legacy:
+    interface: smtp
+    limit: 1
 
 peers:
   indico-peers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ line-length = 99
 target-version = ["py38"]
 
 [tool.coverage.report]
-fail_under = 96
+fail_under = 97
 show_missing = true
 
 # Linting tools configuration

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -28,7 +28,7 @@ Charm for Indico on kubernetes.
 
 Attrs:  on: Redis relation charm events. 
 
-<a href="../src/charm.py#L64"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L65"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/smtp_observer.py.md
+++ b/src-docs/smtp_observer.py.md
@@ -12,7 +12,7 @@ The SMTP relation observer.
 ## <kbd>class</kbd> `SmtpObserver`
 The SMTP integrator relation observer. 
 
-<a href="../src/smtp_observer.py#L21"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/smtp_observer.py#L19"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/smtp_observer.py.md
+++ b/src-docs/smtp_observer.py.md
@@ -1,0 +1,40 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/smtp_observer.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `smtp_observer.py`
+The SMTP relation observer. 
+
+
+
+---
+
+## <kbd>class</kbd> `SmtpObserver`
+The SMTP integrator relation observer. 
+
+<a href="../src/smtp_observer.py#L21"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(charm: CharmBase)
+```
+
+Initialize the observer and register event handlers. 
+
+
+
+**Args:**
+ 
+ - <b>`charm`</b>:  The parent charm to attach the observer to. 
+
+
+---
+
+#### <kbd>property</kbd> model
+
+Shortcut for more simple access the model. 
+
+
+
+

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -18,7 +18,7 @@ Exception raised when a charm configuration is found to be invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L27"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L29"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -65,7 +65,7 @@ Configuration for accessing Indico through proxy.
 
 ---
 
-<a href="../src/state.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L51"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_env`
 
@@ -83,6 +83,25 @@ Instantiate ProxyConfig from juju charm environment.
 
 ---
 
+## <kbd>class</kbd> `SmtpConfig`
+SMTP configuration. 
+
+
+
+**Attributes:**
+ 
+ - <b>`login`</b>:  SMTP user. 
+ - <b>`password`</b>:  SMTP passwaord. 
+ - <b>`port`</b>:  SMTP port. 
+ - <b>`host`</b>:  SMTP host. 
+ - <b>`use_tls`</b>:  whether TLS is enabled. 
+
+
+
+
+
+---
+
 ## <kbd>class</kbd> `State`
 The Indico operator charm state. 
 
@@ -91,13 +110,14 @@ The Indico operator charm state.
 **Attributes:**
  
  - <b>`proxy_config`</b>:  Proxy configuration. 
+ - <b>`smtp_config`</b>:  SMTP configuration. 
 
 
 
 
 ---
 
-<a href="../src/state.py#L77"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L99"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -18,7 +18,7 @@ Exception raised when a charm configuration is found to be invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L29"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L30"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -65,7 +65,7 @@ Configuration for accessing Indico through proxy.
 
 ---
 
-<a href="../src/state.py#L51"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_env`
 
@@ -117,12 +117,15 @@ The Indico operator charm state.
 
 ---
 
-<a href="../src/state.py#L99"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
 ```python
-from_charm(charm: CharmBase) → State
+from_charm(
+    charm: CharmBase,
+    smtp_relation_data: Optional[SmtpRelationData]
+) → State
 ```
 
 Initialize the state from charm. 
@@ -132,6 +135,7 @@ Initialize the state from charm.
 **Args:**
  
  - <b>`charm`</b>:  The charm root IndicoOperatorCharm. 
+ - <b>`smtp_relation_data`</b>:  SMTP relation data. 
 
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -72,7 +72,9 @@ class IndicoOperatorCharm(CharmBase):
         self.database = DatabaseObserver(self)
         self.smtp = SmtpObserver(self)
         try:
-            self.state = State.from_charm(self)
+            self.state = State.from_charm(
+                self, smtp_relation_data=self.smtp.smtp.get_relation_data()
+            )
         except CharmConfigInvalidError as exc:
             self.unit.status = ops.BlockedStatus(exc.msg)
             return
@@ -565,12 +567,12 @@ class IndicoOperatorCharm(CharmBase):
             },
         }
 
-        if self.smtp.smtp_config:
-            env_config["SMTP_LOGIN"] = self.smtp.smtp_config.login
-            env_config["SMTP_PASSWORD"] = self.smtp.smtp_config.password
-            env_config["SMTP_PORT"] = self.smtp.smtp_config.port
-            env_config["SMTP_SERVER"] = self.smtp.smtp_config.host
-            env_config["SMTP_USE_TLS"] = self.smtp.smtp_config.use_tls
+        if self.state.smtp_config:
+            env_config["SMTP_LOGIN"] = self.state.smtp_config.login
+            env_config["SMTP_PASSWORD"] = self.state.smtp_config.password
+            env_config["SMTP_PORT"] = self.state.smtp_config.port
+            env_config["SMTP_SERVER"] = self.state.smtp_config.host
+            env_config["SMTP_USE_TLS"] = self.state.smtp_config.use_tls
 
         # Required for monitoring Celery
         celery_config = {"worker_send_task_events": True, "task_send_sent_event": True}

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,6 +32,7 @@ from ops.model import (
 from ops.pebble import ExecError
 
 from database_observer import DatabaseObserver
+from smtp_observer import SmtpObserver
 from state import CharmConfigInvalidError, ProxyConfig, State
 
 logger = logging.getLogger(__name__)
@@ -69,6 +70,7 @@ class IndicoOperatorCharm(CharmBase):
         """
         super().__init__(*args)
         self.database = DatabaseObserver(self)
+        self.smtp = SmtpObserver(self)
         try:
             self.state = State.from_charm(self)
         except CharmConfigInvalidError as exc:
@@ -558,15 +560,17 @@ class IndicoOperatorCharm(CharmBase):
             "SERVICE_HOSTNAME": self._get_external_hostname(),
             "SERVICE_PORT": self._get_external_port(),
             "SERVICE_SCHEME": self._get_external_scheme(),
-            "SMTP_LOGIN": self.config["smtp_login"],
-            "SMTP_PASSWORD": self.config["smtp_password"],
-            "SMTP_PORT": self.config["smtp_port"],
-            "SMTP_SERVER": self.config["smtp_server"],
-            "SMTP_USE_TLS": self.config["smtp_use_tls"],
             "STORAGE_DICT": {
                 "default": "fs:/srv/indico/archive",
             },
         }
+
+        if self.smtp.smtp_config:
+            env_config["SMTP_LOGIN"] = self.smtp.smtp_config.login
+            env_config["SMTP_PASSWORD"] = self.smtp.smtp_config.password
+            env_config["SMTP_PORT"] = self.smtp.smtp_config.port
+            env_config["SMTP_SERVER"] = self.smtp.smtp_config.host
+            env_config["SMTP_USE_TLS"] = self.smtp.smtp_config.use_tls
 
         # Required for monitoring Celery
         celery_config = {"worker_send_task_events": True, "task_send_sent_event": True}

--- a/src/smtp_observer.py
+++ b/src/smtp_observer.py
@@ -1,0 +1,51 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""The SMTP relation observer."""
+import logging
+
+from charms.smtp_integrator.v0.smtp import SmtpDataAvailableEvent, SmtpRequires, TransportSecurity
+from ops.charm import CharmBase
+from ops.framework import Object
+
+from state import SmtpConfig
+
+logger = logging.getLogger(__name__)
+
+
+class SmtpObserver(Object):
+    """The SMTP integrator relation observer."""
+
+    _RELATION_NAME = "smtp-legacy"
+
+    def __init__(self, charm: CharmBase):
+        """Initialize the observer and register event handlers.
+
+        Args:
+            charm: The parent charm to attach the observer to.
+        """
+        super().__init__(charm, "smtp-observer")
+        self._charm = charm
+        self.smtp = SmtpRequires(
+            self._charm,
+            relation_name=self._RELATION_NAME,
+        )
+        self.smtp_config = None
+        self.framework.observe(
+            self.smtp.on.smtp_data_available, self._saml_relation_data_available
+        )
+
+    def _saml_relation_data_available(self, event: SmtpDataAvailableEvent) -> None:
+        """Handle the relation data available event.
+
+        Args:
+            event: the relation event.
+        """
+        self.smtp_config = SmtpConfig(
+            host=event.host,
+            port=event.port,
+            login=event.user,
+            password=event.password,
+            use_tls=event.transport_security is not TransportSecurity.NONE,
+        )
+        self._charm.on.config_changed.emit()

--- a/src/smtp_observer.py
+++ b/src/smtp_observer.py
@@ -4,11 +4,9 @@
 """The SMTP relation observer."""
 import logging
 
-from charms.smtp_integrator.v0.smtp import SmtpDataAvailableEvent, SmtpRequires, TransportSecurity
+from charms.smtp_integrator.v0.smtp import SmtpRequires
 from ops.charm import CharmBase
 from ops.framework import Object
-
-from state import SmtpConfig
 
 logger = logging.getLogger(__name__)
 
@@ -35,17 +33,6 @@ class SmtpObserver(Object):
             self.smtp.on.smtp_data_available, self._smtp_relation_data_available
         )
 
-    def _smtp_relation_data_available(self, event: SmtpDataAvailableEvent) -> None:
-        """Handle the relation data available event.
-
-        Args:
-            event: the relation event.
-        """
-        self.smtp_config = SmtpConfig(
-            host=event.host,
-            port=event.port,
-            login=event.user,
-            password=event.password,
-            use_tls=event.transport_security is not TransportSecurity.NONE,
-        )
+    def _smtp_relation_data_available(self, _) -> None:
+        """Handle the relation data available event."""
         self._charm.on.config_changed.emit()

--- a/src/smtp_observer.py
+++ b/src/smtp_observer.py
@@ -35,4 +35,5 @@ class SmtpObserver(Object):
 
     def _smtp_relation_data_available(self, _) -> None:
         """Handle the relation data available event."""
+        # A config changes is emited to avoid a huge refactor at this point.
         self._charm.on.config_changed.emit()

--- a/src/smtp_observer.py
+++ b/src/smtp_observer.py
@@ -32,10 +32,10 @@ class SmtpObserver(Object):
         )
         self.smtp_config = None
         self.framework.observe(
-            self.smtp.on.smtp_data_available, self._saml_relation_data_available
+            self.smtp.on.smtp_data_available, self._smtp_relation_data_available
         )
 
-    def _saml_relation_data_available(self, event: SmtpDataAvailableEvent) -> None:
+    def _smtp_relation_data_available(self, event: SmtpDataAvailableEvent) -> None:
         """Handle the relation data available event.
 
         Args:

--- a/src/smtp_observer.py
+++ b/src/smtp_observer.py
@@ -35,5 +35,5 @@ class SmtpObserver(Object):
 
     def _smtp_relation_data_available(self, _) -> None:
         """Handle the relation data available event."""
-        # A config changes is emited to avoid a huge refactor at this point.
+        # A config changes is emitted to avoid a huge refactor at this point.
         self._charm.on.config_changed.emit()

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -12,6 +12,7 @@ import pytest
 from ops.testing import Harness
 
 from charm import IndicoOperatorCharm
+from state import SmtpConfig
 from tests.unit.test_base import TestBase
 
 
@@ -132,11 +133,6 @@ class TestCore(TestBase):
         self.assertEqual("support-tech@mydomain.local", updated_plan_env["INDICO_SUPPORT_EMAIL"])
         self.assertEqual("support@mydomain.local", updated_plan_env["INDICO_PUBLIC_SUPPORT_EMAIL"])
         self.assertEqual("noreply@mydomain.local", updated_plan_env["INDICO_NO_REPLY_EMAIL"])
-        self.assertEqual("", updated_plan_env["SMTP_SERVER"])
-        self.assertEqual(25, updated_plan_env["SMTP_PORT"])
-        self.assertEqual("", updated_plan_env["SMTP_LOGIN"])
-        self.assertEqual("", updated_plan_env["SMTP_PASSWORD"])
-        self.assertTrue(updated_plan_env["SMTP_USE_TLS"])
         self.assertFalse(updated_plan_env["CUSTOMIZATION_DEBUG"])
         self.assertEqual("default", updated_plan_env["ATTACHMENT_STORAGE"])
         storage_dict = literal_eval(updated_plan_env["STORAGE_DICT"])
@@ -158,6 +154,13 @@ class TestCore(TestBase):
         mock_exec.return_value = MagicMock(wait_output=MagicMock(return_value=("", None)))
         self.set_up_all_relations()
         self.harness.set_leader(True)
+        self.harness.charm.smtp.smtp_config = SmtpConfig(
+            host="localhost",
+            port=8025,
+            login="user",
+            password="pass",  # nosec
+            use_tls=False,
+        )
 
         self.harness.container_pebble_ready("indico")
 
@@ -182,15 +185,15 @@ class TestCore(TestBase):
         self.assertEqual("support-tech@mydomain.local", updated_plan_env["INDICO_SUPPORT_EMAIL"])
         self.assertEqual("support@mydomain.local", updated_plan_env["INDICO_PUBLIC_SUPPORT_EMAIL"])
         self.assertEqual("noreply@mydomain.local", updated_plan_env["INDICO_NO_REPLY_EMAIL"])
-        self.assertEqual("", updated_plan_env["SMTP_SERVER"])
-        self.assertEqual(25, updated_plan_env["SMTP_PORT"])
-        self.assertEqual("", updated_plan_env["SMTP_LOGIN"])
-        self.assertEqual("", updated_plan_env["SMTP_PASSWORD"])
-        self.assertTrue(updated_plan_env["SMTP_USE_TLS"])
         self.assertFalse(updated_plan_env["CUSTOMIZATION_DEBUG"])
         self.assertEqual("default", updated_plan_env["ATTACHMENT_STORAGE"])
         storage_dict = literal_eval(updated_plan_env["STORAGE_DICT"])
         self.assertEqual("fs:/srv/indico/archive", storage_dict["default"])
+        self.assertEqual("localhost", updated_plan_env["SMTP_SERVER"])
+        self.assertEqual(8025, updated_plan_env["SMTP_PORT"])
+        self.assertEqual("user", updated_plan_env["SMTP_LOGIN"])
+        self.assertEqual("pass", updated_plan_env["SMTP_PASSWORD"])
+        self.assertFalse(updated_plan_env["SMTP_USE_TLS"])
 
         service = self.harness.model.unit.get_container("indico").get_service("indico")
         self.assertTrue(service.is_running())
@@ -207,6 +210,13 @@ class TestCore(TestBase):
 
         self.set_up_all_relations()
         self.harness.set_leader(True)
+        self.harness.charm.smtp.smtp_config = SmtpConfig(
+            host="localhost",
+            port=8025,
+            login="user",
+            password="pass",  # nosec
+            use_tls=False,
+        )
 
         self.harness.container_pebble_ready("indico-celery")
 
@@ -232,17 +242,17 @@ class TestCore(TestBase):
         self.assertEqual("support-tech@mydomain.local", updated_plan_env["INDICO_SUPPORT_EMAIL"])
         self.assertEqual("support@mydomain.local", updated_plan_env["INDICO_PUBLIC_SUPPORT_EMAIL"])
         self.assertEqual("noreply@mydomain.local", updated_plan_env["INDICO_NO_REPLY_EMAIL"])
-        self.assertEqual("", updated_plan_env["SMTP_SERVER"])
-        self.assertEqual(25, updated_plan_env["SMTP_PORT"])
-        self.assertEqual("", updated_plan_env["SMTP_LOGIN"])
-        self.assertEqual("", updated_plan_env["SMTP_PASSWORD"])
-        self.assertTrue(updated_plan_env["SMTP_USE_TLS"])
         self.assertFalse(updated_plan_env["CUSTOMIZATION_DEBUG"])
         self.assertEqual("default", updated_plan_env["ATTACHMENT_STORAGE"])
         storage_dict = literal_eval(updated_plan_env["STORAGE_DICT"])
         self.assertEqual("fs:/srv/indico/archive", storage_dict["default"])
         self.assertFalse(literal_eval(updated_plan_env["INDICO_AUTH_PROVIDERS"]))
         self.assertFalse(literal_eval(updated_plan_env["INDICO_IDENTITY_PROVIDERS"]))
+        self.assertEqual("localhost", updated_plan_env["SMTP_SERVER"])
+        self.assertEqual(8025, updated_plan_env["SMTP_PORT"])
+        self.assertEqual("user", updated_plan_env["SMTP_LOGIN"])
+        self.assertEqual("pass", updated_plan_env["SMTP_PASSWORD"])
+        self.assertFalse(updated_plan_env["SMTP_USE_TLS"])
 
         service = self.harness.model.unit.get_container("indico-celery").get_service(
             "indico-celery"
@@ -271,11 +281,6 @@ class TestCore(TestBase):
                 "indico_no_reply_email": "noreply@email.local",
                 "saml_target_url": "https://login.ubuntu.com/saml/",
                 "site_url": "https://example.local:8080",
-                "smtp_server": "localhost",
-                "smtp_port": 8025,
-                "smtp_login": "user",
-                "smtp_password": "pass",
-                "smtp_use_tls": False,
                 "s3_storage": "s3:bucket=test-bucket,access_key=12345,secret_key=topsecret",
             }
         )
@@ -290,11 +295,6 @@ class TestCore(TestBase):
         self.assertEqual("noreply@email.local", updated_plan_env["INDICO_NO_REPLY_EMAIL"])
         self.assertEqual("https", updated_plan_env["SERVICE_SCHEME"])
         self.assertEqual(8080, updated_plan_env["SERVICE_PORT"])
-        self.assertEqual("localhost", updated_plan_env["SMTP_SERVER"])
-        self.assertEqual(8025, updated_plan_env["SMTP_PORT"])
-        self.assertEqual("user", updated_plan_env["SMTP_LOGIN"])
-        self.assertEqual("pass", updated_plan_env["SMTP_PASSWORD"])
-        self.assertFalse(updated_plan_env["SMTP_USE_TLS"])
         self.assertTrue(updated_plan_env["CUSTOMIZATION_DEBUG"])
         storage_dict = literal_eval(updated_plan_env["STORAGE_DICT"])
         self.assertEqual("s3", updated_plan_env["ATTACHMENT_STORAGE"])
@@ -340,11 +340,6 @@ class TestCore(TestBase):
         self.assertEqual("example.local", updated_plan_env["SERVICE_HOSTNAME"])
         self.assertEqual("https", updated_plan_env["SERVICE_SCHEME"])
         self.assertEqual(8080, updated_plan_env["SERVICE_PORT"])
-        self.assertEqual("localhost", updated_plan_env["SMTP_SERVER"])
-        self.assertEqual(8025, updated_plan_env["SMTP_PORT"])
-        self.assertEqual("user", updated_plan_env["SMTP_LOGIN"])
-        self.assertEqual("pass", updated_plan_env["SMTP_PASSWORD"])
-        self.assertFalse(updated_plan_env["SMTP_USE_TLS"])
         self.assertTrue(updated_plan_env["CUSTOMIZATION_DEBUG"])
         self.assertEqual("s3", updated_plan_env["ATTACHMENT_STORAGE"])
         storage_dict = literal_eval(updated_plan_env["STORAGE_DICT"])

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -154,7 +154,7 @@ class TestCore(TestBase):
         mock_exec.return_value = MagicMock(wait_output=MagicMock(return_value=("", None)))
         self.set_up_all_relations()
         self.harness.set_leader(True)
-        self.harness.charm.smtp.smtp_config = SmtpConfig(
+        self.harness.charm.state.smtp_config = SmtpConfig(
             host="localhost",
             port=8025,
             login="user",
@@ -210,7 +210,7 @@ class TestCore(TestBase):
 
         self.set_up_all_relations()
         self.harness.set_leader(True)
-        self.harness.charm.smtp.smtp_config = SmtpConfig(
+        self.harness.charm.state.smtp_config = SmtpConfig(
             host="localhost",
             port=8025,
             login="user",

--- a/tests/unit/test_smtp_observer.py
+++ b/tests/unit/test_smtp_observer.py
@@ -28,7 +28,7 @@ class ObservedCharm(ops.CharmBase):
         """
         super().__init__(*args)
         self.smtp = SmtpObserver(self)
-        self.state = State.from_charm(self)
+        self.state = State.from_charm(self, smtp_relation_data=None)
         self.events = []
         self.framework.observe(self.on.config_changed, self._record_event)
 
@@ -66,8 +66,3 @@ def test_smtp_related_emits_config_changed_eventand_updates_charm_state():
         relation_data,
     )
     assert len(harness.charm.events) == 1
-    assert harness.charm.smtp.smtp_config.host == relation_data["host"]
-    assert harness.charm.smtp.smtp_config.port == int(relation_data["port"])
-    assert harness.charm.smtp.smtp_config.login == relation_data["user"]
-    assert harness.charm.smtp.smtp_config.password == relation_data["password"]
-    assert harness.charm.smtp.smtp_config.use_tls

--- a/tests/unit/test_smtp_observer.py
+++ b/tests/unit/test_smtp_observer.py
@@ -1,0 +1,73 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Database observer unit tests."""
+
+import ops
+from ops.testing import Harness
+
+from smtp_observer import SmtpObserver
+from state import State
+
+REQUIRER_METADATA = """
+name: observer-charm
+requires:
+  smtp-legacy:
+    interface: saml
+"""
+
+
+class ObservedCharm(ops.CharmBase):
+    """Class for requirer charm testing."""
+
+    def __init__(self, *args):
+        """Construct.
+
+        Args:
+            args: Variable list of positional arguments passed to the parent constructor.
+        """
+        super().__init__(*args)
+        self.smtp = SmtpObserver(self)
+        self.state = State.from_charm(self)
+        self.events = []
+        self.framework.observe(self.on.config_changed, self._record_event)
+
+    def _record_event(self, event: ops.EventBase) -> None:
+        """Rececord emitted event in the event list.
+
+        Args:
+            event: event.
+        """
+        self.events.append(event)
+
+
+def test_smtp_related_emits_config_changed_eventand_updates_charm_state():
+    """
+    arrange: set up a charm and a smtp relation.
+    act: trigger a relation changed event.
+    assert: a config change event is emitted and the state, updated.
+    """
+    relation_data = {
+        "host": "example.smtp",
+        "port": "25",
+        "user": "example_user",
+        "password": "somepassword",  # nosec
+        "auth_type": "plain",
+        "transport_security": "tls",
+        "domain": "domain",
+    }
+    harness = Harness(ObservedCharm, meta=REQUIRER_METADATA)
+    harness.begin()
+    relation_id = harness.add_relation("smtp-legacy", "smtp-integrator")
+    harness.add_relation_unit(relation_id, "smtp-integrator/0")
+    harness.update_relation_data(
+        relation_id,
+        "smtp-integrator",
+        relation_data,
+    )
+    assert len(harness.charm.events) == 1
+    assert harness.charm.smtp.smtp_config.host == relation_data["host"]
+    assert harness.charm.smtp.smtp_config.port == int(relation_data["port"])
+    assert harness.charm.smtp.smtp_config.login == relation_data["user"]
+    assert harness.charm.smtp.smtp_config.password == relation_data["password"]
+    assert harness.charm.smtp.smtp_config.use_tls


### PR DESCRIPTION
Applicable spec: N/A

### Overview

<!-- A high level overview of the change -->
Retrieve SMTP config from SMTP integrator

### Rationale

<!-- The reason the change is needed -->
Leverage the new SMTP integrator charm

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
* New smtp observer module
* Changes in state
* Changes in charm

### Library Changes

<!-- Any changes to charm libraries -->
* Added smtp lib

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->