### PR TITLE
Add support for customizing favicon

### DIFF
--- a/docs/how-to/customize-theme.md
+++ b/docs/how-to/customize-theme.md
@@ -2,8 +2,8 @@
 
 This charm supports providing static source files for customizing Indico look and feel. Details on how those files should look like can be consulted in [Indico's official documentation](https://docs.getindico.io/en/stable/config/settings/#customization).
 
-If you wish to apply a set of customization files, set the configuration option `customization_sources_url` to the URL of the git repository containing them `juju config [charm_name] customization_sources_url=[value]`. For debugging purposes, you may also want to enable `customization_debug` to get meaningful log messages when the files are accessed.
+If you wish to apply a set of customization files, set the configuration option `customization_sources_url` to the URL of the git repository containing them `juju config [charm_name] customization_sources_url=[value]`. If you want the favicon to be customized too, to publish it as `files/favicon.ico` in the customization repository. For debugging purposes, you may also want to enable `customization_debug` to get meaningful log messages when the files are accessed.
 
-The theme changes can be pulled by running the [refresh-external-resources action](https://charmhub.io/indico/actions#refresh-external-resources). If you want the favicon to be customizad too, you'll have to publish it as `files/favicon.ico`.
+The theme changes can be pulled by running the [refresh-external-resources action](https://charmhub.io/indico/actions#refresh-external-resources).
 
 For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/indico/configure).

--- a/docs/how-to/customize-theme.md
+++ b/docs/how-to/customize-theme.md
@@ -2,7 +2,7 @@
 
 This charm supports providing static source files for customizing Indico look and feel. Details on how those files should look like can be consulted in [Indico's official documentation](https://docs.getindico.io/en/stable/config/settings/#customization).
 
-If you wish to apply a set of customization files, set the configuration option `customization_sources_url` to the URL of the git repository containing them `juju config [charm_name] customization_sources_url=[value]`. If you want the favicon to be customized too, to publish it as `files/favicon.ico` in the customization repository. For debugging purposes, you may also want to enable `customization_debug` to get meaningful log messages when the files are accessed.
+If you wish to apply a set of customization files, set the configuration option `customization_sources_url` to the URL of the git repository containing them `juju config [charm_name] customization_sources_url=[value]`. If you want the favicon to be customized too, publish it as `files/favicon.ico` in the customization repository. For debugging purposes, you may also want to enable `customization_debug` to get meaningful log messages when the files are accessed.
 
 The theme changes can be pulled by running the [refresh-external-resources action](https://charmhub.io/indico/actions#refresh-external-resources).
 

--- a/docs/how-to/customize-theme.md
+++ b/docs/how-to/customize-theme.md
@@ -4,6 +4,6 @@ This charm supports providing static source files for customizing Indico look an
 
 If you wish to apply a set of customization files, set the configuration option `customization_sources_url` to the URL of the git repository containing them `juju config [charm_name] customization_sources_url=[value]`. For debugging purposes, you may also want to enable `customization_debug` to get meaningful log messages when the files are accessed.
 
-The theme changes can be pulled by running the [refresh-external-resources action](https://charmhub.io/indico/actions#refresh-external-resources).
+The theme changes can be pulled by running the [refresh-external-resources action](https://charmhub.io/indico/actions#refresh-external-resources). If you want the favicon to be customizad too, you'll have to publish it as `files/favicon.ico`.
 
 For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/indico/configure).

--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -34,6 +34,24 @@ http {
     listen [::]:8080;
     error_log stderr error;
 
+    location = /images/indico.ico {
+      root /var/empty/nginx;
+      proxy_hide_header Cache-Control;
+      add_header Cache-Control 'no-cache';
+      include common_headers.conf;
+      client_max_body_size 0;
+      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+      proxy_set_header X-Forwarded-Host $http_host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_intercept_errors on;
+      error_page 404 =301 /default_favicon.ico;
+      proxy_pass http://localhost:8081/static/custom/files/favicon.ico;
+    }
+
+    location /default_favicon.ico {
+        alias /srv/indico/static/images/indico.ico;
+    }
+
     location ~ ^/(images|fonts)(.*)/(.+?)(__v[0-9a-f]+)?\.([^.]+)$ {
       alias /srv/indico/static/$1$2/$3.$5;
     }


### PR DESCRIPTION
Applicable spec: <link> N/A

### Overview

<!-- A high level overview of the change -->
Nginx configuration changes so that the favicon can be customized by pushing it among the customization sources in a certain path.

### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->