### PR TITLE
Increase nginx timeout to 300s

### DIFF
--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -72,7 +72,7 @@ http {
       add_header Cache-Control 'no-cache,private';
       include common_headers.conf;
       client_max_body_size 0;
-      proxy_read_timeout 300;
+      proxy_read_timeout 300s;
       proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
       proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -78,6 +78,12 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_pass http://localhost:8081;
 
+      location ~ ^/event/[0-9]+/manage/registration/[0-9]+/registrations/(import|email)$ {
+        # add_header and proxy_set_header are inherited from the / location
+        proxy_hide_header Cache-Control;
+        proxy_pass http://localhost:8081;
+      }
+
       location ~ ^/static/custom/(.*)$ {
         expires 1m;
         proxy_hide_header Cache-Control;

--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -72,15 +72,15 @@ http {
       add_header Cache-Control 'no-cache,private';
       include common_headers.conf;
       client_max_body_size 0;
-      proxy_read_timeout 300;
       proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
       proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_pass http://localhost:8081;
 
-      location ~ ^/event/[0-9]+/manage/registration/[0-9]+/registrations/(import|email)$ {
+      location ~ ^/event/[0-9]+/manage/(.*)$ {
         # add_header and proxy_set_header are inherited from the / location
         proxy_hide_header Cache-Control;
+        proxy_read_timeout 300;
         proxy_pass http://localhost:8081;
       }
 

--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -78,12 +78,6 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_pass http://localhost:8081;
 
-      location ~ ^/event/[0-9]+/manage/registration/[0-9]+/registrations/(import|email)$ {
-        # add_header and proxy_set_header are inherited from the / location
-        proxy_hide_header Cache-Control;
-        proxy_pass http://localhost:8081;
-      }
-
       location ~ ^/static/custom/(.*)$ {
         expires 1m;
         proxy_hide_header Cache-Control;

--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -72,6 +72,7 @@ http {
       add_header Cache-Control 'no-cache,private';
       include common_headers.conf;
       client_max_body_size 0;
+      proxy_read_timeout 300;
       proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
       proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -72,7 +72,7 @@ http {
       add_header Cache-Control 'no-cache,private';
       include common_headers.conf;
       client_max_body_size 0;
-      proxy_read_timeout 300s;
+      proxy_read_timeout 300;
       proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
       proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -81,7 +81,6 @@ http {
       location ~ ^/event/[0-9]+/manage/registration/[0-9]+/registrations/(import|email)$ {
         # add_header and proxy_set_header are inherited from the / location
         proxy_hide_header Cache-Control;
-        proxy_read_timeout 300;
         proxy_pass http://localhost:8081;
       }
 


### PR DESCRIPTION
Applicable spec: <link>
N/A

### Overview

<!-- A high level overview of the change -->
Increase nginx timeout to 300s

### Rationale

<!-- The reason the change is needed -->
Some users are experiencing timeouts when handling large chunks of data

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->