### PR TITLE
Increase timeout for /api/events

### DIFF
--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -77,6 +77,13 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_pass http://localhost:8081;
 
+      location ~ ^/api/events/[0-9]+/(.*)$ {
+        # add_header and proxy_set_header are inherited from the / location
+        proxy_hide_header Cache-Control;
+        proxy_read_timeout 300;
+        proxy_pass http://localhost:8081;
+      }
+
       location ~ ^/event/[0-9]+/manage/(.*)$ {
         # add_header and proxy_set_header are inherited from the / location
         proxy_hide_header Cache-Control;

--- a/tests/integration/test_saml.py
+++ b/tests/integration/test_saml.py
@@ -38,7 +38,7 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
             "site_url": external_url,
             "external_plugins": (
                 "https://github.com/canonical/flask-multipass-saml-groups/releases/download"
-                "/1.2.0/flask_multipass_saml_groups-1.2.0-py3-none-any.whl"
+                "/1.2.1/flask_multipass_saml_groups-1.2.1-py3-none-any.whl"
             ),
         }
     )

--- a/tests/integration/test_saml.py
+++ b/tests/integration/test_saml.py
@@ -37,7 +37,8 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
         {
             "site_url": external_url,
             "external_plugins": (
-                "https://github.com/canonical/flask-multipass-saml-groups/releases/download/1.2.0/flask_multipass_saml_groups-1.2.0-py3-none-any.whl"
+                "https://github.com/canonical/flask-multipass-saml-groups/releases/download"
+                "/1.2.0/flask_multipass_saml_groups-1.2.0-py3-none-any.whl"
             ),
         }
     )

--- a/tests/integration/test_saml.py
+++ b/tests/integration/test_saml.py
@@ -34,13 +34,7 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
     """
     # The linter does not recognize set_config as a method, so this errors must be ignored.
     await app.set_config(  # type: ignore[attr-defined] # pylint: disable=W0106
-        {
-            "site_url": external_url,
-            "external_plugins": (
-                "https://github.com/canonical/flask-multipass-saml-groups/releases/download"
-                "/1.2.1/flask_multipass_saml_groups-1.2.1-py3-none-any.whl"
-            ),
-        }
+        {"site_url": external_url}
     )
     # The linter does not recognize wait_for_idle as a method,
     # since ops_test has a model as Optional, so this error must be ignored.

--- a/tests/integration/test_saml.py
+++ b/tests/integration/test_saml.py
@@ -34,7 +34,12 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
     """
     # The linter does not recognize set_config as a method, so this errors must be ignored.
     await app.set_config(  # type: ignore[attr-defined] # pylint: disable=W0106
-        {"site_url": external_url}
+        {
+            "site_url": external_url,
+            "external_plugins": (
+                "https://github.com/canonical/flask-multipass-saml-groups/releases/download/1.2.0/flask_multipass_saml_groups-1.2.0-py3-none-any.whl"
+            ),
+        }
     )
     # The linter does not recognize wait_for_idle as a method,
     # since ops_test has a model as Optional, so this error must be ignored.


### PR DESCRIPTION
Applicable spec: <link>
N/A

### Overview

<!-- A high level overview of the change -->
Increase timeout for /api/events

### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->