### PR TITLE
install libxmlsec1-dev in overlay

### DIFF
--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -57,7 +57,6 @@ parts:
       - libglib2.0-data
       - libpq-dev
       - libsasl2-dev
-      - libxmlsec1-dev
       - locales
       - pkg-config
       - postgresql-client
@@ -66,6 +65,8 @@ parts:
       - texlive-plain-generic
       - texlive-xetex
       - libpangocairo-1.0-0 # required for python3.12
+    overlay-packages:
+      - libxmlsec1-dev
     stage-snaps:
       - celery-prometheus-exporter/latest/edge
       - gtrkiller-statsd-prometheus-exporter/latest/edge

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -115,6 +115,12 @@ async def app_fixture(
     )
     await ops_test.model.wait_for_idle(status="active", raise_on_error=False)
 
+    # Install saml_groups plugin
+    await application.set_config(
+        {
+            "external_plugins": "https://github.com/canonical/flask-multipass-saml-groups/releases/download/1.2.1/flask_multipass_saml_groups-1.2.1-py3-none-any.whl"
+        }
+    )
     yield application
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -114,11 +114,11 @@ async def app_fixture(
         ops_test.model.add_relation(app_name, "nginx-ingress-integrator"),
     )
     await ops_test.model.wait_for_idle(status="active", raise_on_error=False)
-
     # Install saml_groups plugin
+    # Disabling line-too-long lint since we are installing the plugin via gh release
     await application.set_config(
         {
-            "external_plugins": "https://github.com/canonical/flask-multipass-saml-groups/releases/download/1.2.1/flask_multipass_saml_groups-1.2.1-py3-none-any.whl"
+            "external_plugins": "https://github.com/canonical/flask-multipass-saml-groups/releases/download/1.2.1/flask_multipass_saml_groups-1.2.1-py3-none-any.whl"  # noqa: E501 pylint: disable=line-too-long
         }
     )
     yield application


### PR DESCRIPTION
We ran into an issue during internal deployment where the `libxmlsec1-dev` package was not present in the `indico` container image even though we specified it to be installed during `stage-packages`. This PR moves it to `overlay-packages` as we suspect maintainer scripts would likely need to be run for `libxmlsec1-dev` to be installed correctly.

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->