### PR TITLE
Remove site url

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,10 +13,9 @@ jobs:
       modules: '["test_actions.py", "test_charm.py", "test_s3.py", "test_saml.py"]'
       trivy-fs-enabled: true
       trivy-image-config: "trivy.yaml"
-      zap-before-command: "curl -k -H \"Host: indico.local\" https://localhost/bootstrap --data-raw 'csrf_token=00000000-0000-0000-0000-000000000000&first_name=admin&last_name=admin&email=admin%40admin.com&username=admin&password=lunarlobster&confirm_password=lunarlobster&affiliation=Canonical'"
+      zap-before-command: "curl -k -H \"Host: indico.local\" http://localhost/bootstrap --data-raw 'csrf_token=00000000-0000-0000-0000-000000000000&first_name=admin&last_name=admin&email=admin%40admin.com&username=admin&password=lunarlobster&confirm_password=lunarlobster&affiliation=Canonical'"
       zap-enabled: true
       zap-cmd-options: '-T 60 -z "-addoninstall jython" --hook "/zap/wrk/tests/zap/hook.py"'
       zap-target: localhost
       zap-target-port: 80
-      zap-target-protocol: "https"
       zap-rules-file-name: "zap_rules.tsv"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,7 +13,7 @@ jobs:
       modules: '["test_actions.py", "test_charm.py", "test_s3.py", "test_saml.py"]'
       trivy-fs-enabled: true
       trivy-image-config: "trivy.yaml"
-      zap-before-command: "curl -H \"Host: indico.local\" https://localhost/bootstrap --data-raw 'csrf_token=00000000-0000-0000-0000-000000000000&first_name=admin&last_name=admin&email=admin%40admin.com&username=admin&password=lunarlobster&confirm_password=lunarlobster&affiliation=Canonical'"
+      zap-before-command: "curl -k -H \"Host: indico.local\" https://localhost/bootstrap --data-raw 'csrf_token=00000000-0000-0000-0000-000000000000&first_name=admin&last_name=admin&email=admin%40admin.com&username=admin&password=lunarlobster&confirm_password=lunarlobster&affiliation=Canonical'"
       zap-enabled: true
       zap-cmd-options: '-T 60 -z "-addoninstall jython" --hook "/zap/wrk/tests/zap/hook.py"'
       zap-target: localhost

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,7 +1,7 @@
 name: Integration tests
 
 on:
-  push:
+  pull_request:
 
 jobs:
   integration-tests:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,7 +1,7 @@
 name: Integration tests
 
 on:
-  pull_request:
+  push:
 
 jobs:
   integration-tests:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,9 +13,10 @@ jobs:
       modules: '["test_actions.py", "test_charm.py", "test_s3.py", "test_saml.py"]'
       trivy-fs-enabled: true
       trivy-image-config: "trivy.yaml"
-      zap-before-command: "curl -H \"Host: indico.local\" http://localhost/bootstrap --data-raw 'csrf_token=00000000-0000-0000-0000-000000000000&first_name=admin&last_name=admin&email=admin%40admin.com&username=admin&password=lunarlobster&confirm_password=lunarlobster&affiliation=Canonical'"
+      zap-before-command: "curl -H \"Host: indico.local\" https://localhost/bootstrap --data-raw 'csrf_token=00000000-0000-0000-0000-000000000000&first_name=admin&last_name=admin&email=admin%40admin.com&username=admin&password=lunarlobster&confirm_password=lunarlobster&affiliation=Canonical'"
       zap-enabled: true
       zap-cmd-options: '-T 60 -z "-addoninstall jython" --hook "/zap/wrk/tests/zap/hook.py"'
       zap-target: localhost
       zap-target-port: 80
+      zap-target-protocol: "https"
       zap-rules-file-name: "zap_rules.tsv"

--- a/config.yaml
+++ b/config.yaml
@@ -30,7 +30,3 @@ options:
     type: string
     description: Email address of the technical manager of the Indico instance.
     default: 'support-tech@mydomain.local'
-  site_url:
-    type: string
-    description: URL through which Indico is accessed by users.
-    default: ''

--- a/docs/how-to/configure-the-external-hostname.md
+++ b/docs/how-to/configure-the-external-hostname.md
@@ -1,17 +1,13 @@
 # How to configure the external hostname
 
-This charm exposes the `site_url` configuration option to specify the external hostname of the application.
-
-To expose the application it is recommended to set that configuration option and deploy and integrate with the [Nginx Ingress Integrator Operator](https://charmhub.io/nginx-ingress-integrator), that will be automatically configured with the values provided by the charm.
+To expose the application, deploy and integrate with the [Nginx Ingress Integrator Operator](https://charmhub.io/nginx-ingress-integrator). The charm will be automatically exposed at `[application name].local`, being `[application name]` the charm name. To provide a different hostname, set the [service-hostname](https://charmhub.io/nginx-ingress-integrator/configuration#service-hostname) configuration for the Nginx Ingress Integrator Operator.
 
 Assuming Indico is already up and running as `indico`, you'll need to run the following commands:
 ```
-# Configure the external hostname
-juju config indico site_url=indico.local
 # Deploy and integrate with the Nginx Ingress Integrator charm
 juju deploy nginx-ingress-integrator
 juju trust nginx-ingress-integrator --scope cluster # if RBAC is enabled
 juju integrate nginx-ingress-integrator indico
+# Configure the external hostname
+juju config nginx-ingress-integrator service-hostname=indico.example
 ```
-
-For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/indico/configure).

--- a/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
+++ b/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
@@ -119,7 +119,7 @@ class _NginxRouteCharmEvents(ops.charm.CharmEvents):
     nginx_route_broken = ops.framework.EventSource(_NginxRouteBrokenEvent)
 
 
-class _NginxRouteRequirer(ops.framework.Object):
+class NginxRouteRequirer(ops.framework.Object):
     """This class defines the functionality for the 'requires' side of the 'nginx-route' relation.
 
     Hook events observed:
@@ -148,7 +148,7 @@ class _NginxRouteRequirer(ops.framework.Object):
             self._config_reconciliation,
         )
         # Set default values.
-        self._config: typing.Dict[str, typing.Union[str, int, bool]] = {
+        self.config: typing.Dict[str, typing.Union[str, int, bool]] = {
             "service-namespace": self._charm.model.name,
             **config,
         }
@@ -167,7 +167,7 @@ class _NginxRouteRequirer(ops.framework.Object):
             }
             for delete_key in delete_keys:
                 del relation_app_data[delete_key]
-            relation_app_data.update({k: str(v) for k, v in self._config.items()})
+            relation_app_data.update({k: str(v) for k, v in self.config.items()})
 
 
 # C901 is ignored since the method has too many ifs but wouldn't be
@@ -195,7 +195,7 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches,to
     session_cookie_max_age: typing.Optional[int] = None,
     tls_secret_name: typing.Optional[str] = None,
     nginx_route_relation_name: str = "nginx-route",
-) -> None:
+) -> NginxRouteRequirer:
     """Set up nginx-route relation handlers on the requirer side.
 
     This function must be invoked in the charm class constructor.
@@ -242,6 +242,8 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches,to
         nginx_route_relation_name: Specifies the relation name of
             the relation handled by this requirer class. The relation
             must have the nginx-route interface.
+    Returns:
+        the NginxRouteRequirer.
     """
     config: typing.Dict[str, typing.Union[str, int, bool]] = {}
     if service_hostname is not None:
@@ -281,7 +283,7 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches,to
     if tls_secret_name is not None:
         config["tls-secret-name"] = tls_secret_name
 
-    _NginxRouteRequirer(
+    return NginxRouteRequirer(
         charm=charm, config=config, nginx_route_relation_name=nginx_route_relation_name
     )
 

--- a/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
+++ b/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
@@ -119,7 +119,7 @@ class _NginxRouteCharmEvents(ops.charm.CharmEvents):
     nginx_route_broken = ops.framework.EventSource(_NginxRouteBrokenEvent)
 
 
-class NginxRouteRequirer(ops.framework.Object):
+class _NginxRouteRequirer(ops.framework.Object):
     """This class defines the functionality for the 'requires' side of the 'nginx-route' relation.
 
     Hook events observed:
@@ -148,7 +148,7 @@ class NginxRouteRequirer(ops.framework.Object):
             self._config_reconciliation,
         )
         # Set default values.
-        self.config: typing.Dict[str, typing.Union[str, int, bool]] = {
+        self._config: typing.Dict[str, typing.Union[str, int, bool]] = {
             "service-namespace": self._charm.model.name,
             **config,
         }
@@ -163,11 +163,11 @@ class NginxRouteRequirer(ops.framework.Object):
             delete_keys = {
                 relation_field
                 for relation_field in relation_app_data
-                if relation_field not in self.config
+                if relation_field not in self._config
             }
             for delete_key in delete_keys:
                 del relation_app_data[delete_key]
-            relation_app_data.update({k: str(v) for k, v in self.config.items()})
+            relation_app_data.update({k: str(v) for k, v in self._config.items()})
 
 
 # C901 is ignored since the method has too many ifs but wouldn't be
@@ -195,7 +195,7 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches,to
     session_cookie_max_age: typing.Optional[int] = None,
     tls_secret_name: typing.Optional[str] = None,
     nginx_route_relation_name: str = "nginx-route",
-) -> NginxRouteRequirer:
+) -> None:
     """Set up nginx-route relation handlers on the requirer side.
 
     This function must be invoked in the charm class constructor.
@@ -242,8 +242,6 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches,to
         nginx_route_relation_name: Specifies the relation name of
             the relation handled by this requirer class. The relation
             must have the nginx-route interface.
-    Returns:
-        the NginxRouteRequirer.
     """
     config: typing.Dict[str, typing.Union[str, int, bool]] = {}
     if service_hostname is not None:
@@ -283,7 +281,7 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches,to
     if tls_secret_name is not None:
         config["tls-secret-name"] = tls_secret_name
 
-    return NginxRouteRequirer(
+    _NginxRouteRequirer(
         charm=charm, config=config, nginx_route_relation_name=nginx_route_relation_name
     )
 

--- a/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
+++ b/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
@@ -163,7 +163,7 @@ class NginxRouteRequirer(ops.framework.Object):
             delete_keys = {
                 relation_field
                 for relation_field in relation_app_data
-                if relation_field not in self._config
+                if relation_field not in self.config
             }
             for delete_key in delete_keys:
                 del relation_app_data[delete_key]

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -26,7 +26,7 @@ Charm for Indico on kubernetes.
 
 Attrs:  on: Redis relation charm events. 
 
-<a href="../src/charm.py#L57"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -122,7 +122,12 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         self._grafana_dashboards = GrafanaDashboardProvider(self)
 
     def _require_nginx_route(self) -> NginxRouteRequirer:
-        """Require nginx ingress."""
+        """Require nginx ingress.
+
+        Returns:
+            The NginxRouteRequirer.
+        """
+        print("PASOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
         return require_nginx_route(
             charm=self,
             service_hostname=f"{self.app.name}.local",
@@ -142,6 +147,11 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         )
 
     def _get_site_url(self) -> str:
+        """Get the site URL.
+
+        Returns:
+            The site's URL.
+        """
         return f"https://{self._get_external_hostname()}"
 
     def _get_external_hostname(self) -> str:
@@ -153,7 +163,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         return self.nginx_route.config.get("external_hostname")
 
     def _get_external_scheme(self) -> str:
-        """Extract and return schema from site_url.
+        """Get the HTTP schema.
 
         Returns:
             The HTTP schema.
@@ -161,7 +171,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         return "https"
 
     def _get_external_port(self) -> Optional[int]:
-        """Extract and return port from site_url.
+        """Get the HTTP port.
 
         Returns:
             The port number.

--- a/src/charm.py
+++ b/src/charm.py
@@ -127,7 +127,6 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         Returns:
             The NginxRouteRequirer.
         """
-        print("PASOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
         return require_nginx_route(
             charm=self,
             service_hostname=f"{self.app.name}.local",
@@ -160,7 +159,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         Returns:
             The hostname configured in the NGINX ingress integrator.
         """
-        return self.nginx_route.config.get("external_hostname")
+        return self.nginx_route.config.get("service-hostname")
 
     def _get_external_scheme(self) -> str:
         """Get the HTTP schema.
@@ -169,14 +168,6 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             The HTTP schema.
         """
         return "https"
-
-    def _get_external_port(self) -> Optional[int]:
-        """Get the HTTP port.
-
-        Returns:
-            The port number.
-        """
-        return 443
 
     def _are_relations_ready(self, _) -> bool:
         """Check if the needed relations are established.
@@ -503,7 +494,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             "REDIS_CACHE_URL": self.redis_cache.url,
             "SECRET_KEY": self._get_indico_secret_key_from_relation(),
             "SERVICE_HOSTNAME": self._get_external_hostname(),
-            "SERVICE_PORT": self._get_external_port(),
+            "SERVICE_PORT": "",
             "SERVICE_SCHEME": self._get_external_scheme(),
             "STORAGE_DICT": {
                 "default": "fs:/srv/indico/archive",

--- a/src/charm.py
+++ b/src/charm.py
@@ -145,14 +145,6 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             for container_name in self.model.unit.containers
         )
 
-    def _get_site_url(self) -> str:
-        """Get the site URL.
-
-        Returns:
-            The site's URL.
-        """
-        return f"https://{self._get_external_hostname()}"
-
     def _get_external_hostname(self) -> str:
         """Extract and return hostname from the nginx-route relation data.
 
@@ -160,14 +152,6 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             The hostname configured in the NGINX ingress integrator.
         """
         return self.nginx_route.config.get("service-hostname")
-
-    def _get_external_scheme(self) -> str:
-        """Get the HTTP schema.
-
-        Returns:
-            The HTTP schema.
-        """
-        return "https"
 
     def _are_relations_ready(self, _) -> bool:
         """Check if the needed relations are established.
@@ -495,7 +479,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             "SECRET_KEY": self._get_indico_secret_key_from_relation(),
             "SERVICE_HOSTNAME": self._get_external_hostname(),
             "SERVICE_PORT": "",
-            "SERVICE_SCHEME": self._get_external_scheme(),
+            "SERVICE_SCHEME": "https",
             "STORAGE_DICT": {
                 "default": "fs:/srv/indico/archive",
             },
@@ -526,7 +510,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             saml_config: Dict[str, Any] = {
                 "strict": True,
                 "sp": {
-                    "entityId": self._get_site_url(),
+                    "entityId": f"https://{self._get_external_hostname()}",
                 },
                 "idp": {
                     "entityId": self.state.saml_config.entity_id,

--- a/src/charm.py
+++ b/src/charm.py
@@ -126,7 +126,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         """Require nginx ingress."""
         return require_nginx_route(
             charm=self,
-            service_hostname=None,
+            service_hostname=self.app.name,
             service_name=self.app.name,
             service_port=8080,
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,8 +8,7 @@ import logging
 import os
 import typing
 from re import findall
-from typing import Any, Dict, Iterator, List, Optional, Tuple
-from urllib.parse import urlparse
+from typing import Any, Dict, Iterator, List, Optional
 
 import ops.lib
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
@@ -141,9 +140,9 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             self.unit.get_container(container_name).can_connect()
             for container_name in self.model.unit.containers
         )
-    
+
     def _get_site_url(self) -> str:
-        return f"https://{self._get_external_hostname}"
+        return f"https://{self._get_external_hostname()}"
 
     def _get_external_hostname(self) -> str:
         """Extract and return hostname from the nginx-route relation data.

--- a/src/charm.py
+++ b/src/charm.py
@@ -125,7 +125,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         """Require nginx ingress."""
         return require_nginx_route(
             charm=self,
-            service_hostname=self.app.name,
+            service_hostname=f"{self.app.name}.local",
             service_name=self.app.name,
             service_port=8080,
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -141,14 +141,17 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             self.unit.get_container(container_name).can_connect()
             for container_name in self.model.unit.containers
         )
+    
+    def _get_site_url(self) -> str:
+        return f"https://{self._get_external_hostname}"
 
     def _get_external_hostname(self) -> str:
-        """Extract and return hostname from site_url or default to [application name].local.
+        """Extract and return hostname from the nginx-route relation data.
 
         Returns:
-            The site URL defined as part of the site_url configuration or a default value.
+            The hostname configured in the NGINX ingress integrator.
         """
-        return self.nginx_route.config["external_hostname"]
+        return self.nginx_route.config.get("external_hostname")
 
     def _get_external_scheme(self) -> str:
         """Extract and return schema from site_url.
@@ -523,7 +526,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             saml_config: Dict[str, Any] = {
                 "strict": True,
                 "sp": {
-                    "entityId": self.config["site_url"],
+                    "entityId": self._get_site_url(),
                 },
                 "idp": {
                     "entityId": self.state.saml_config.entity_id,

--- a/src/charm.py
+++ b/src/charm.py
@@ -479,7 +479,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             "SECRET_KEY": self._get_indico_secret_key_from_relation(),
             "SERVICE_HOSTNAME": self._get_external_hostname(),
             "SERVICE_PORT": "",
-            "SERVICE_SCHEME": "https",
+            "SERVICE_SCHEME": "http",
             "STORAGE_DICT": {
                 "default": "fs:/srv/indico/archive",
             },

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -60,7 +60,6 @@ def requests_timeout():
 async def app_fixture(
     ops_test: OpsTest,
     app_name: str,
-    hostname: str,
     pytestconfig: Config,
 ):
     """Indico charm used for integration testing.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -81,9 +81,7 @@ async def app_fixture(
         ops_test.model.deploy("redis-k8s", "redis-broker", channel="latest/edge"),
         ops_test.model.deploy("redis-k8s", "redis-cache", channel="latest/edge"),
         ops_test.model.deploy(
-            "nginx-ingress-integrator", channel="latest/edge", series="focal", config={
-                "service-hostname": hostname,
-            }, trust=True
+            "nginx-ingress-integrator", channel="latest/edge", series="focal", trust=True
         ),
     )
     await ops_test.model.wait_for_idle(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,10 +14,10 @@ from pytest import Config, fixture
 from pytest_operator.plugin import OpsTest
 
 
-@fixture(scope="module", name="external_url")
-def external_url_fixture():
+@fixture(scope="module", name="hostname")
+def hostname_fixture():
     """Provides the external URL for Indico."""
-    return "https://events.staging.canonical.com"
+    return "events.staging.canonical.com"
 
 
 @fixture(scope="module")
@@ -60,6 +60,7 @@ def requests_timeout():
 async def app_fixture(
     ops_test: OpsTest,
     app_name: str,
+    hostname: str,
     pytestconfig: Config,
 ):
     """Indico charm used for integration testing.
@@ -80,7 +81,9 @@ async def app_fixture(
         ops_test.model.deploy("redis-k8s", "redis-broker", channel="latest/edge"),
         ops_test.model.deploy("redis-k8s", "redis-cache", channel="latest/edge"),
         ops_test.model.deploy(
-            "nginx-ingress-integrator", channel="latest/edge", series="focal", trust=True
+            "nginx-ingress-integrator", channel="latest/edge", series="focal", config={
+                "service-hostname": hostname,
+            }, trust=True
         ),
     )
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -48,7 +48,7 @@ async def test_indico_is_up(ops_test: OpsTest, app: Application):
         f"https://{app.name}.local/bootstrap",
         timeout=10,
         verify=False,
-        proxies = {"https": f"http://{address}"},
+        proxies={"https": f"http://{address}:8080"},
     )
     assert response.status_code == 200
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -48,7 +48,7 @@ async def test_indico_is_up(ops_test: OpsTest, app: Application):
         f"https://{app.name}.local/bootstrap",
         timeout=10,
         verify=False,
-        proxies={"https": f"http://127.0.0.1"},
+        proxies={"https": f"https://127.0.0.1"},
     )
     assert response.status_code == 200
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -45,10 +45,11 @@ async def test_indico_is_up(ops_test: OpsTest, app: Application):
     # Send request to bootstrap page and set Host header to app_name (which the application
     # expects)
     response = requests.get(
-        f"https://{app.name}.local/bootstrap",
+        f"https://127.0.0.1/bootstrap",
+        headers={"Host": f"{app.name}.local"},
         timeout=10,
         verify=False,
-        proxies={"https": f"https://127.0.0.1"},
+        # proxies={"https": f"https://127.0.0.1"},
     )
     assert response.status_code == 200
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -32,7 +32,7 @@ async def test_active(app: Application):
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_indico_is_up(ops_test: OpsTest, app: Application):
+async def test_indico_is_up(ops_test: OpsTest, app: Application, hostname: str):
     """Check that the bootstrap page is reachable.
 
     Assume that the charm has already been built and is running.
@@ -45,7 +45,7 @@ async def test_indico_is_up(ops_test: OpsTest, app: Application):
     # Send request to bootstrap page and set Host header to app_name (which the application
     # expects)
     response = requests.get(
-        f"http://{address}:8080/bootstrap", headers={"Host": f"{app.name}.local"}, timeout=10
+        f"http://{address}:8080/bootstrap", headers={"Host": hostname}, timeout=10
     )
     assert response.status_code == 200
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -48,7 +48,7 @@ async def test_indico_is_up(ops_test: OpsTest, app: Application):
         f"https://{app.name}.local/bootstrap",
         timeout=10,
         verify=False,
-        proxies = {"https": f"http://{address}:8080"},
+        proxies = {"https": f"http://{address}"},
     )
     assert response.status_code == 200
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -48,7 +48,7 @@ async def test_indico_is_up(ops_test: OpsTest, app: Application):
         f"https://{app.name}.local/bootstrap",
         timeout=10,
         verify=False,
-        proxies={"https": f"http://{address}:8080"},
+        proxies={"https": f"http://127.0.0.1"},
     )
     assert response.status_code == 200
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -45,7 +45,7 @@ async def test_indico_is_up(ops_test: OpsTest, app: Application):
     # Send request to bootstrap page and set Host header to app_name (which the application
     # expects)
     response = requests.get(
-        f"https://127.0.0.1/bootstrap",
+        f"http://127.0.0.1/bootstrap",
         headers={"Host": f"{app.name}.local"},
         timeout=10,
         verify=False,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -48,7 +48,7 @@ async def test_indico_is_up(ops_test: OpsTest, app: Application):
         f"https://{app.name}.local:8080/bootstrap",
         timeout=10,
         verify=False,
-        proxies = {"https": "http://127.0.0.1:8080"},
+        proxies = {"https": f"http://{address}:8080"},
     )
     assert response.status_code == 200
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -45,7 +45,10 @@ async def test_indico_is_up(ops_test: OpsTest, app: Application):
     # Send request to bootstrap page and set Host header to app_name (which the application
     # expects)
     response = requests.get(
-        f"http://{address}:8080/bootstrap", headers={"Host": f"{app.name}.local"}, timeout=10
+        f"https://{address}:8080/bootstrap",
+        headers={"Host": f"{app.name}.local"},
+        timeout=10,
+        verify=False,
     )
     assert response.status_code == 200
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -32,7 +32,7 @@ async def test_active(app: Application):
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_indico_is_up(ops_test: OpsTest, app: Application, hostname: str):
+async def test_indico_is_up(ops_test: OpsTest, app: Application):
     """Check that the bootstrap page is reachable.
 
     Assume that the charm has already been built and is running.
@@ -45,7 +45,7 @@ async def test_indico_is_up(ops_test: OpsTest, app: Application, hostname: str):
     # Send request to bootstrap page and set Host header to app_name (which the application
     # expects)
     response = requests.get(
-        f"http://{address}:8080/bootstrap", headers={"Host": hostname}, timeout=10
+        f"http://{address}:8080/bootstrap", headers={"Host": f"{app.name}.local"}, timeout=10
     )
     assert response.status_code == 200
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -45,10 +45,10 @@ async def test_indico_is_up(ops_test: OpsTest, app: Application):
     # Send request to bootstrap page and set Host header to app_name (which the application
     # expects)
     response = requests.get(
-        f"https://{address}:8080/bootstrap",
-        headers={"Host": f"{app.name}.local"},
+        f"https://{app.name}.local:8080/bootstrap",
         timeout=10,
         verify=False,
+        proxies = {"https": "http://127.0.0.1:8080"},
     )
     assert response.status_code == 200
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -45,7 +45,7 @@ async def test_indico_is_up(ops_test: OpsTest, app: Application):
     # Send request to bootstrap page and set Host header to app_name (which the application
     # expects)
     response = requests.get(
-        f"https://{app.name}.local:8080/bootstrap",
+        f"https://{app.name}.local/bootstrap",
         timeout=10,
         verify=False,
         proxies = {"https": f"http://{address}:8080"},

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -38,18 +38,13 @@ async def test_indico_is_up(ops_test: OpsTest, app: Application):
     Assume that the charm has already been built and is running.
     """
     assert ops_test.model
-    # Read the IP address of indico
-    status = await ops_test.model.get_status()
-    unit = list(status.applications[app.name].units)[0]
-    address = status["applications"][app.name]["units"][unit]["address"]
     # Send request to bootstrap page and set Host header to app_name (which the application
     # expects)
     response = requests.get(
-        f"http://127.0.0.1/bootstrap",
+        "http://127.0.0.1/bootstrap",
         headers={"Host": f"{app.name}.local"},
         timeout=10,
-        verify=False,
-        # proxies={"https": f"https://127.0.0.1"},
+        verify=False,  # nosec
     )
     assert response.status_code == 200
 

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -24,7 +24,7 @@ async def test_s3(app: Application, s3_integrator: Application, ops_test: OpsTes
     """
     assert ops_test.model
     await ops_test.model.applications["nginx-ingress-integrator"].set_config(
-        {"external_hostname": hostname}
+        {"service-hostname": hostname}
     )
     # The linter does not recognize wait_for_idle as a method,
     # since ops_test has a model as Optional, so this error must be ignored.

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -22,6 +22,7 @@ async def test_s3(app: Application, s3_integrator: Application, ops_test: OpsTes
     act: do nothing.
     assert: the pebble plan matches the S3 values as configured by the integrator.
     """
+    assert ops_test.model
     await ops_test.model.applications["nginx-ingress-integrator"].set_config(
         {"external_hostname": hostname}
     )

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -16,12 +16,18 @@ from pytest_operator.plugin import OpsTest
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("s3_integrator")
-async def test_s3(app: Application, s3_integrator: Application, ops_test: OpsTest):
+async def test_s3(app: Application, s3_integrator: Application, ops_test: OpsTest, hostname: str):
     """
     arrange: given charm integrated with S3.
     act: do nothing.
     assert: the pebble plan matches the S3 values as configured by the integrator.
     """
+    await ops_test.model.applications["nginx-ingress-integrator"].set_config(
+        {"external_hostname": hostname}
+    )
+    # The linter does not recognize wait_for_idle as a method,
+    # since ops_test has a model as Optional, so this error must be ignored.
+    await ops_test.model.wait_for_idle(status="active")  # type: ignore[union-attr]
     # Application actually does have units
     return_code, stdout, _ = await ops_test.juju(
         "ssh", "--container", app.name, app.units[0].name, "pebble", "plan"  # type: ignore

--- a/tests/integration/test_saml.py
+++ b/tests/integration/test_saml.py
@@ -11,7 +11,6 @@ from unittest.mock import patch
 import pytest
 import requests
 import urllib3.exceptions
-from ops import Application
 from pytest_operator.plugin import OpsTest
 
 
@@ -30,9 +29,9 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
     act: configure a SAML target url and fire SAML authentication
     assert: The SAML authentication process is executed successfully.
     """
-    await ops_test.model.applications["nginx-ingress-integrator"].set_config(
-        {"external_hostname": hostname}
-    )
+    assert ops_test.model
+    nginx_ingress_integrator_app = ops_test.model.applications["nginx-ingress-integrator"]
+    await nginx_ingress_integrator_app.set_config({"external_hostname": hostname})
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     original_getaddrinfo = socket.getaddrinfo
@@ -104,6 +103,4 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
         )
         assert dashboard_page.status_code == 200
         # Revert SAML config for zap to be able to run
-        await ops_test.model.applications["nginx-ingress-integrator"].set_config(
-            {"external_hostname": ""}
-        )
+        await nginx_ingress_integrator_app.set_config({"external_hostname": ""})

--- a/tests/integration/test_saml.py
+++ b/tests/integration/test_saml.py
@@ -32,6 +32,7 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
     assert ops_test.model
     nginx_ingress_integrator_app = ops_test.model.applications["nginx-ingress-integrator"]
     await nginx_ingress_integrator_app.set_config({"service-hostname": hostname})
+    await ops_test.model.wait_for_idle(status="active")
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     original_getaddrinfo = socket.getaddrinfo

--- a/tests/integration/test_saml.py
+++ b/tests/integration/test_saml.py
@@ -31,7 +31,7 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
     """
     assert ops_test.model
     nginx_ingress_integrator_app = ops_test.model.applications["nginx-ingress-integrator"]
-    await nginx_ingress_integrator_app.set_config({"external_hostname": hostname})
+    await nginx_ingress_integrator_app.set_config({"service-hostname": hostname})
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     original_getaddrinfo = socket.getaddrinfo
@@ -103,4 +103,4 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
         )
         assert dashboard_page.status_code == 200
         # Revert SAML config for zap to be able to run
-        await nginx_ingress_integrator_app.set_config({"external_hostname": ""})
+        await nginx_ingress_integrator_app.set_config({"service-hostname": ""})

--- a/tests/integration/test_saml.py
+++ b/tests/integration/test_saml.py
@@ -103,4 +103,4 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
         )
         assert dashboard_page.status_code == 200
         # Revert SAML config for zap to be able to run
-        await nginx_ingress_integrator_app.set_config({"service-hostname": ""})
+        await nginx_ingress_integrator_app.reset_config(["service-hostname"])

--- a/tests/integration/test_saml.py
+++ b/tests/integration/test_saml.py
@@ -7,7 +7,6 @@
 import re
 import socket
 from unittest.mock import patch
-from urllib.parse import urlparse
 
 import pytest
 import requests
@@ -79,7 +78,7 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
         )
         assert len(saml_response_matches), saml_callback.text
         session.post(
-            f"https://{host}/multipass/saml/ubuntu/acs",
+            f"https://{hostname}/multipass/saml/ubuntu/acs",
             data={
                 "RelayState": "None",
                 "SAMLResponse": saml_response_matches[0],

--- a/tests/integration/test_saml.py
+++ b/tests/integration/test_saml.py
@@ -102,6 +102,3 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
         )
         assert dashboard_page.status_code == 200
         # Revert SAML config for zap to be able to run
-        await app.set_config(  # type: ignore[attr-defined] # pylint: disable=W0106
-            {"site_url": ""}
-        )

--- a/tests/integration/test_saml.py
+++ b/tests/integration/test_saml.py
@@ -19,7 +19,7 @@ from pytest_operator.plugin import OpsTest
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("saml_integrator")
 async def test_saml_auth(  # pylint: disable=too-many-arguments
-    app: Application,
+    ops_test: OpsTest,
     saml_email: str,
     saml_password: str,
     requests_timeout: float,
@@ -30,6 +30,9 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
     act: configure a SAML target url and fire SAML authentication
     assert: The SAML authentication process is executed successfully.
     """
+    await ops_test.model.applications["nginx-ingress-integrator"].set_config(
+        {"external_hostname": hostname}
+    )
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     original_getaddrinfo = socket.getaddrinfo
@@ -101,3 +104,6 @@ async def test_saml_auth(  # pylint: disable=too-many-arguments
         )
         assert dashboard_page.status_code == 200
         # Revert SAML config for zap to be able to run
+        await ops_test.model.applications["nginx-ingress-integrator"].set_config(
+            {"external_hostname": ""}
+        )

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -44,7 +44,7 @@ class TestBase(unittest.TestCase):
             "redis-cache", "redis-cache", unit_data={"hostname": "cache-host", "port": "1011"}
         )
         self.nginx_route_relation_id = self.harness.add_relation(  # pylint: disable=W0201
-            "nginx-route", "ingress"
+            "nginx-route", "ingress", app_data={"service-hostname": "example.local"}
         )
 
     def is_ready(self, apps: List[str]):
@@ -58,8 +58,8 @@ class TestBase(unittest.TestCase):
 
     def set_relations_and_leader(self):
         """Set Indico relations, the leader and check container readiness."""
-        self.set_up_all_relations()
         self.harness.set_leader(True)
+        self.set_up_all_relations()
         self.is_ready(
             [
                 "indico",

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -126,7 +126,7 @@ class TestCore(TestBase):
             updated_plan_env["SECRET_KEY"],
         )
         self.assertEqual("indico.local", updated_plan_env["SERVICE_HOSTNAME"])
-        self.assertIsNone(updated_plan_env["SERVICE_PORT"])
+        self.assertEqual("", updated_plan_env["SERVICE_PORT"])
         self.assertEqual("redis://cache-host:1011", updated_plan_env["REDIS_CACHE_URL"])
         self.assertFalse(updated_plan_env["ENABLE_ROOMBOOKING"])
         self.assertEqual("support-tech@mydomain.local", updated_plan_env["INDICO_SUPPORT_EMAIL"])
@@ -178,7 +178,7 @@ class TestCore(TestBase):
         secret_value = secret.get_content().get("secret-key")
         self.assertEqual(secret_value, updated_plan_env["SECRET_KEY"])
         self.assertEqual("indico.local", updated_plan_env["SERVICE_HOSTNAME"])
-        self.assertIsNone(updated_plan_env["SERVICE_PORT"])
+        self.assertEqual("", updated_plan_env["SERVICE_PORT"])
         self.assertEqual("redis://cache-host:1011", updated_plan_env["REDIS_CACHE_URL"])
         self.assertFalse(updated_plan_env["ENABLE_ROOMBOOKING"])
         self.assertEqual("support-tech@mydomain.local", updated_plan_env["INDICO_SUPPORT_EMAIL"])
@@ -255,7 +255,6 @@ class TestCore(TestBase):
         nginx_route_relation_data = self.harness.get_relation_data(
             self.nginx_route_relation_id, self.harness.charm.app
         )
-        print(nginx_route_relation_data)
         self.assertEqual("indico.local", nginx_route_relation_data["service-hostname"])
 
         updated_plan = self.harness.get_container_pebble_plan("indico").to_dict()
@@ -267,7 +266,7 @@ class TestCore(TestBase):
         self.assertEqual("public@email.local", updated_plan_env["INDICO_PUBLIC_SUPPORT_EMAIL"])
         self.assertEqual("noreply@email.local", updated_plan_env["INDICO_NO_REPLY_EMAIL"])
         self.assertEqual("https", updated_plan_env["SERVICE_SCHEME"])
-        self.assertEqual(443, updated_plan_env["SERVICE_PORT"])
+        self.assertEqual("", updated_plan_env["SERVICE_PORT"])
         self.assertTrue(updated_plan_env["CUSTOMIZATION_DEBUG"])
         storage_dict = literal_eval(updated_plan_env["STORAGE_DICT"])
         self.assertEqual("s3", updated_plan_env["ATTACHMENT_STORAGE"])

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -38,7 +38,7 @@ class TestCore(TestBase):
         act: trigger a configuration update
         assert: the charm is in waiting status until all relations have been set
         """
-        self.harness.update_config({"site_url": "foo"})
+        self.harness.update_config({"customization_debug": True})
         self.assertEqual(
             self.harness.model.unit.status,
             ops.WaitingStatus("Waiting for redis-broker availability"),
@@ -246,20 +246,28 @@ class TestCore(TestBase):
                 "indico_support_email": "example@email.local",
                 "indico_public_support_email": "public@email.local",
                 "indico_no_reply_email": "noreply@email.local",
-                "site_url": "https://example.local:8080",
             }
         )
+
+        # ops testing harness doesn't rerun the charm's __init__
+        # manually rerun the _require_nginx_route function
+        # self.harness.charm._require_nginx_route()
+        nginx_route_relation_data = self.harness.get_relation_data(
+            self.nginx_route_relation_id, self.harness.charm.app
+        )
+        print(nginx_route_relation_data)
+        self.assertEqual("indico.local", nginx_route_relation_data["service-hostname"])
 
         updated_plan = self.harness.get_container_pebble_plan("indico").to_dict()
         updated_plan_env = updated_plan["services"]["indico"]["environment"]
 
-        self.assertEqual("example.local", updated_plan_env["SERVICE_HOSTNAME"])
+        self.assertEqual("indico.local", updated_plan_env["SERVICE_HOSTNAME"])
         self.assertTrue(updated_plan_env["ENABLE_ROOMBOOKING"])
         self.assertEqual("example@email.local", updated_plan_env["INDICO_SUPPORT_EMAIL"])
         self.assertEqual("public@email.local", updated_plan_env["INDICO_PUBLIC_SUPPORT_EMAIL"])
         self.assertEqual("noreply@email.local", updated_plan_env["INDICO_NO_REPLY_EMAIL"])
         self.assertEqual("https", updated_plan_env["SERVICE_SCHEME"])
-        self.assertEqual(8080, updated_plan_env["SERVICE_PORT"])
+        self.assertEqual(443, updated_plan_env["SERVICE_PORT"])
         self.assertTrue(updated_plan_env["CUSTOMIZATION_DEBUG"])
         storage_dict = literal_eval(updated_plan_env["STORAGE_DICT"])
         self.assertEqual("s3", updated_plan_env["ATTACHMENT_STORAGE"])
@@ -274,13 +282,13 @@ class TestCore(TestBase):
         auth_providers = literal_eval(updated_plan_env["INDICO_AUTH_PROVIDERS"])
         self.assertEqual("saml", auth_providers["ubuntu"]["type"])
         self.assertEqual(
-            "https://example.local:8080",
+            "https://indico.local",
             auth_providers["ubuntu"]["saml_config"]["sp"]["entityId"],
         )
         auth_providers = literal_eval(updated_plan_env["INDICO_AUTH_PROVIDERS"])
         self.assertEqual("saml", auth_providers["ubuntu"]["type"])
         applied_saml_config = auth_providers["ubuntu"]["saml_config"]
-        self.assertEqual("https://example.local:8080", applied_saml_config["sp"]["entityId"])
+        self.assertEqual("https://indico.local", applied_saml_config["sp"]["entityId"])
         self.assertEqual(saml_config.entity_id, applied_saml_config["idp"]["entityId"])
         self.assertEqual(saml_config.certificates[0], applied_saml_config["idp"]["x509cert"])
         self.assertEqual(
@@ -316,31 +324,6 @@ class TestCore(TestBase):
         mock_exec.assert_any_call(
             ["pip", "install", "--upgrade", "git+https://example.git/#subdirectory=themes_cern"],
             environment={},
-        )
-
-        self.harness.update_config({"site_url": "https://example.local"})
-        # ops testing harness doesn't rerun the charm's __init__
-        # manually rerun the _require_nginx_route function
-        self.harness.charm._require_nginx_route()
-        nginx_route_relation_data = self.harness.get_relation_data(
-            self.nginx_route_relation_id, self.harness.charm.app
-        )
-        self.assertEqual("example.local", nginx_route_relation_data["service-hostname"])
-
-    @patch.object(ops.Container, "exec")
-    def test_config_changed_when_config_invalid(self, mock_exec):
-        """
-        arrange: charm created and relations established
-        act: trigger an invalid site URL configuration change for the charm
-        assert: the unit reaches blocked status
-        """
-        mock_exec.return_value = MagicMock(wait_output=MagicMock(return_value=("", None)))
-
-        self.set_relations_and_leader()
-        self.harness.update_config({"site_url": "example.local"})
-        self.assertEqual(
-            self.harness.model.unit.status,
-            ops.BlockedStatus("Configuration option site_url is not valid"),
         )
 
     @patch.object(ops.Container, "exec")

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -249,14 +249,6 @@ class TestCore(TestBase):
             }
         )
 
-        # ops testing harness doesn't rerun the charm's __init__
-        # manually rerun the _require_nginx_route function
-        # self.harness.charm._require_nginx_route()
-        nginx_route_relation_data = self.harness.get_relation_data(
-            self.nginx_route_relation_id, self.harness.charm.app
-        )
-        self.assertEqual("indico.local", nginx_route_relation_data["service-hostname"])
-
         updated_plan = self.harness.get_container_pebble_plan("indico").to_dict()
         updated_plan_env = updated_plan["services"]["indico"]["environment"]
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -257,7 +257,7 @@ class TestCore(TestBase):
         self.assertEqual("example@email.local", updated_plan_env["INDICO_SUPPORT_EMAIL"])
         self.assertEqual("public@email.local", updated_plan_env["INDICO_PUBLIC_SUPPORT_EMAIL"])
         self.assertEqual("noreply@email.local", updated_plan_env["INDICO_NO_REPLY_EMAIL"])
-        self.assertEqual("https", updated_plan_env["SERVICE_SCHEME"])
+        self.assertEqual("http", updated_plan_env["SERVICE_SCHEME"])
         self.assertEqual("", updated_plan_env["SERVICE_PORT"])
         self.assertTrue(updated_plan_env["CUSTOMIZATION_DEBUG"])
         storage_dict = literal_eval(updated_plan_env["STORAGE_DICT"])


### PR DESCRIPTION
Applicable spec: <link>
N/A

### Overview

<!-- A high level overview of the change -->
Remove the `site_url` configuration option and configure the external hostname through the `nginx-route` relation.

### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
charm.py

### Library Changes

<!-- Any changes to charm libraries -->
NA

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->