### PR TITLE
Fix OpenSSL system CA certificate issue in indico image

### DIFF
--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -78,8 +78,8 @@ parts:
       cp $CRAFT_PART_INSTALL/lib/python3.12/site-packages/indico/web/indico.wsgi srv/indico/indico.wsgi
       cp -R $CRAFT_PART_INSTALL/lib/python3.12/site-packages/indico/web/static srv/indico/static
       # Copy root certificates
-      mkdir -p etc/ssl/certs/
-      cp /etc/ssl/certs/ca-certificates.crt etc/ssl/certs/
+      mkdir -p etc/ssl/
+      cp /etc/ssl/certs/ca-certificates.crt etc/ssl/cert.pem
   copy-config:
     plugin: dump
     source: .

--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -78,8 +78,8 @@ parts:
       cp $CRAFT_PART_INSTALL/lib/python3.12/site-packages/indico/web/indico.wsgi srv/indico/indico.wsgi
       cp -R $CRAFT_PART_INSTALL/lib/python3.12/site-packages/indico/web/static srv/indico/static
       # Copy root certificates
-      mkdir -p etc/ssl/
-      cp /etc/ssl/certs/ca-certificates.crt etc/ssl/cert.pem
+      mkdir -p usr/lib/ssl
+      cp /etc/ssl/certs/ca-certificates.crt usr/lib/ssl/cert.pem
   copy-config:
     plugin: dump
     source: .


### PR DESCRIPTION
In the current Indico image, the `/etc/ssl/certs/ca-certificates.crt` file is copied to the same location inside the Indico rock container. However, this is not a location recognized by OpenSSL as the system CA certificates. Consequently, this causes Python, which depends on OpenSSL, to fail in establishing TLS connections, particularly as observed in the `smtplib` library.

Update the `rockcraft.yaml` file to copy the `ca-certificates.crt` to `/usr/lib/ssl/cert.pem`, which is OpenSSL's default SSL certificate file on Ubuntu.