### PR TITLE
Fix libcurl system CA certificate issue in the Indico image

### DIFF
--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -79,7 +79,9 @@ parts:
       cp -R $CRAFT_PART_INSTALL/lib/python3.12/site-packages/indico/web/static srv/indico/static
       # Copy root certificates
       mkdir -p usr/lib/ssl
-      cp /etc/ssl/certs/ca-certificates.crt usr/lib/ssl/cert.pem
+      mkdir -p etc/ssl/certs/
+      cp /etc/ssl/certs/ca-certificates.crt etc/ssl/certs/ca-certificates.crt
+      ln -s /etc/ssl/certs/ca-certificates.crt usr/lib/ssl/cert.pem
   copy-config:
     plugin: dump
     source: .


### PR DESCRIPTION
In the previous pull request https://github.com/canonical/indico-operator/pull/412, the `/etc/ssl/certs/ca-certificates.crt` file was moved to `/usr/lib/ssl/cert.pem` to accommodate applications that use OpenSSL, since `/usr/lib/ssl/cert.pem` is the default location for the CA bundle on Ubuntu. However, this change breaks applications that use libcurl (such as git) because, on Ubuntu, libcurl defaults to using `/etc/ssl/certs/ca-certificates.crt` as the system CA.

In this pull request, the CA certificate file is kept in both locations using a symbolic link.