### PR TITLE
Updated Indico Rock to Ubuntu 24.04

### DIFF
--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -1,16 +1,12 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-package-repositories:
-  - type: apt
-    ppa: deadsnakes/ppa
-    priority: always
 
 name: indico
 summary: Indico rock
 description: Indico OCI image for the Indico charm
 version: "1.0"
-base: ubuntu@22.04
-build-base: ubuntu@22.04
+base: ubuntu@24.04
+build-base: ubuntu@24.04
 license: Apache-2.0
 platforms:
   amd64:
@@ -24,7 +20,6 @@ parts:
   indico:
     plugin: python
     build-environment:
-      - PARTS_PYTHON_INTERPRETER: python3.12
       - UWSGI_EMBED_PLUGINS: stats_pusher_statsd
     python-packages:
       - setuptools
@@ -39,8 +34,6 @@ parts:
       - ./autocreate
     source: plugins
     build-packages:
-      - python3.12-venv
-      - python3.12-dev
       - build-essential
       - libpq-dev
       - libsasl2-dev
@@ -48,9 +41,8 @@ parts:
       - pkg-config
       - wget
     stage-packages:
-      - python3.12-venv
-      - python3.12-dev
-      - bash
+      - python3-venv
+      - python3-dev
       - build-essential
       - ca-certificates
       - git-core
@@ -68,20 +60,17 @@ parts:
       - libpangocairo-1.0-0 # required for python3.12
     overlay-packages:
       - libxmlsec1-dev
+      - bash
     stage-snaps:
       - celery-prometheus-exporter/latest/edge
       - gtrkiller-statsd-prometheus-exporter/latest/edge
-    override-prime: |
+    override-stage: |
+      mkdir -p --mode=775 $CRAFT_PART_INSTALL/srv/indico/{archive,cache,custom,etc,log,tmp}
+      cp $CRAFT_PART_INSTALL/lib/python3.12/site-packages/indico/web/indico.wsgi $CRAFT_PART_INSTALL/srv/indico/indico.wsgi
+      cp -R $CRAFT_PART_INSTALL/lib/python3.12/site-packages/indico/web/static $CRAFT_PART_INSTALL/srv/indico/
+      chown -R 2000:2000 $CRAFT_PART_INSTALL/srv/indico
+      cp /etc/ssl/certs/ca-certificates.crt  $CRAFT_PART_INSTALL/etc/ssl/certs/ca-certificates.crt
       craftctl default
-      /bin/bash -c "mkdir -p --mode=775 srv/indico/{archive,cache,custom,etc,log,tmp}"
-      cp $CRAFT_PART_INSTALL/lib/python3.12/site-packages/indico/web/indico.wsgi srv/indico/indico.wsgi
-      /bin/bash -c "chown 2000:2000 srv/indico srv/indico/{archive,cache,custom,etc,indico.wsgi,log,tmp}"
-      cp -R $CRAFT_PART_INSTALL/lib/python3.12/site-packages/indico/web/static srv/indico/static
-      # Copy root certificates
-      mkdir -p usr/lib/ssl
-      mkdir -p etc/ssl/certs/
-      cp /etc/ssl/certs/ca-certificates.crt etc/ssl/certs/ca-certificates.crt
-      ln -s /etc/ssl/certs/ca-certificates.crt usr/lib/ssl/cert.pem
   copy-config:
     plugin: dump
     source: .

--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -60,7 +60,6 @@ parts:
       - libpangocairo-1.0-0 # required for python3.12
     overlay-packages:
       - libxmlsec1-dev
-      - bash
     stage-snaps:
       - celery-prometheus-exporter/latest/edge
       - gtrkiller-statsd-prometheus-exporter/latest/edge

--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -70,6 +70,8 @@ parts:
       chown -R 2000:2000 $CRAFT_PART_INSTALL/srv/indico
       cp /etc/ssl/certs/ca-certificates.crt  $CRAFT_PART_INSTALL/etc/ssl/certs/ca-certificates.crt
       craftctl default
+    prime:
+      - -usr/lib/python3.12/EXTERNALLY-MANAGED
   copy-config:
     plugin: dump
     source: .

--- a/src/charm.py
+++ b/src/charm.py
@@ -680,7 +680,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             plugins: List of plugins to be installed.
         """
         if plugins:
-            install_command = ["pip", "install", "--upgrade", "--break-system-packages"] + plugins
+            install_command = ["pip", "install", "--upgrade"] + plugins
             logger.info("About to run: %s", " ".join(install_command))
             process = container.exec(
                 install_command,

--- a/src/charm.py
+++ b/src/charm.py
@@ -680,7 +680,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             plugins: List of plugins to be installed.
         """
         if plugins:
-            install_command = ["pip", "install", "--upgrade"] + plugins
+            install_command = ["pip", "install", "--upgrade", "--break-system-packages"] + plugins
             logger.info("About to run: %s", " ".join(install_command))
             process = container.exec(
                 install_command,


### PR DESCRIPTION
Updated Indico Rock to Ubuntu 24.04

### Overview

Made changes to rockcraft.yaml file to use base Ubuntu 24.04
<!-- A high level overview of the change -->

### Rationale
After Indico 3.3 update Python 3.12 was needed and we did that with deadsnake repo but a better way is to use the Ubuntu version that comes with Python 3.12 which is Ubuntu 24.04
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->