### PR TITLE
feat: Update Charm to use Redis HA

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -45,6 +45,10 @@ SAML_GROUPS_PLUGIN_NAME = "saml_groups"
 UWSGI_TOUCH_RELOAD = "/srv/indico/indico.wsgi"
 
 
+class InvalidRedisNameError(Exception):
+    """Represents invalid redis name error."""
+
+
 class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attributes
     """Charm for Indico on kubernetes.
 
@@ -380,6 +384,41 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         }
         return typing.cast(ops.pebble.LayerDict, layer)
 
+    def _get_redis_url(self, redis_name: str) -> Optional[str]:
+        """Get Url for redis charm.
+
+        Args:
+            redis_name (str): Name of the redis charm to connect to.
+
+        Returns:
+            Url for the redis charm.
+
+        Raises:
+           InvalidRedisNameError: If redis name is invalid
+        """
+        if redis_name == "redis-broker":
+            redis = self.redis_broker
+        elif redis_name == "redis-cache":
+            redis = self.redis_cache
+        else:
+            raise InvalidRedisNameError(f"Invalid Redis name: {redis_name}")
+
+        relation = self.model.get_relation(redis.relation_name)
+        if not relation:
+            return None
+        relation_app_data = relation.data[relation.app]
+        relation_unit_data = redis.relation_data
+
+        try:
+            redis_hostname = str(
+                relation_app_data.get("leader-host", relation_unit_data["hostname"])
+            )
+            redis_port = int(relation_unit_data["port"])
+            return f"redis://{redis_hostname}:{redis_port}"
+        except KeyError:
+            return None
+        return None
+
     def _get_celery_prometheus_exporter_pebble_config(self, container) -> ops.pebble.LayerDict:
         """Generate pebble config for the celery-prometheus-exporter container.
 
@@ -399,7 +438,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
                     "summary": "Celery Exporter",
                     "command": (
                         "celery-exporter"
-                        f" --broker-url={self.redis_broker.url}"
+                        f" --broker-url={self._get_redis_url('redis-broker')}"
                         " --retry-interval=5"
                     ),
                     "environment": indico_env_config,
@@ -516,7 +555,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
 
         env_config = {
             "ATTACHMENT_STORAGE": "default",
-            "CELERY_BROKER": self.redis_broker.url,
+            "CELERY_BROKER": self._get_redis_url("redis-broker"),
             "CE_ACCEPT_CONTENT": "json,pickle",
             "CUSTOMIZATION_DEBUG": self.config["customization_debug"],
             "ENABLE_ROOMBOOKING": self.config["enable_roombooking"],
@@ -530,7 +569,7 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             "LANG": "C.UTF-8",
             "LC_ALL": "C.UTF-8",
             "LC_LANG": "C.UTF-8",
-            "REDIS_CACHE_URL": self.redis_cache.url,
+            "REDIS_CACHE_URL": self._get_redis_url("redis-cache"),
             "SECRET_KEY": self._get_indico_secret_key_from_relation(),
             "SERVICE_HOSTNAME": self._get_external_hostname(),
             "SERVICE_PORT": self._get_external_port(),

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -37,12 +37,31 @@ class TestBase(unittest.TestCase):
         )
 
         self.harness.add_relation("indico-peers", self.harness.charm.app.name)
-        self.harness.add_relation(
-            "redis-broker", "redis-broker", unit_data={"hostname": "broker-host", "port": "1010"}
+        redis_broker_relation_id = self.harness.add_relation(
+            "redis-broker",
+            "redis-broker",
+            unit_data={"hostname": "broker-host", "port": "1010"},
+            app_data={"leader-host": "broker-host"},
         )
-        self.harness.add_relation(
-            "redis-cache", "redis-cache", unit_data={"hostname": "cache-host", "port": "1011"}
+        self.harness.add_relation_unit(redis_broker_relation_id, "redis-broker/1")
+        self.harness.update_relation_data(
+            redis_broker_relation_id,
+            "redis-broker/1",
+            {"hostname": "broker-host-1", "port": "1010"},
         )
+        redis_cache_relation_id = self.harness.add_relation(
+            "redis-cache",
+            "redis-cache",
+            unit_data={"hostname": "cache-host", "port": "1011"},
+            app_data={"leader-host": "cache-host"},
+        )
+        self.harness.add_relation_unit(redis_cache_relation_id, "redis-cache/1")
+        self.harness.update_relation_data(
+            redis_cache_relation_id,
+            "redis-cache/1",
+            {"hostname": "cache-host-1", "port": "1011"},
+        )
+
         self.nginx_route_relation_id = self.harness.add_relation(  # pylint: disable=W0201
             "nginx-route", "ingress"
         )

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -29,8 +29,96 @@ def test_proxyconfig_invalid(monkeypatch: pytest.MonkeyPatch):
     assert harness.model.unit.status.name == ops.BlockedStatus().name
 
 
-class TestCore(TestBase):
+class TestCore(TestBase):  # pylint: disable=too-many-public-methods
     """Indico charm unit tests."""
+
+    def test_redis_ha(self):
+        """
+        arrange: charm created
+        act: change leader-host
+        assert: the charm gets the changed url
+        """
+        self.setUp()
+        broker_host = "broker-host"
+        broker_port = "1010"
+        cache_host = "cache-host"
+        cache_port = "1011"
+
+        redis_broker_relation_id = self.harness.add_relation(
+            "redis-broker",
+            "redis-broker",
+            unit_data={"hostname": broker_host, "port": broker_port},
+            app_data={"leader-host": broker_host},
+        )
+        self.harness.add_relation_unit(redis_broker_relation_id, "redis-broker/1")
+        self.harness.update_relation_data(
+            redis_broker_relation_id,
+            "redis-broker/1",
+            {"hostname": "broker-host-1", "port": broker_port},
+        )
+        redis_cache_relation_id = self.harness.add_relation(
+            "redis-cache",
+            "redis-cache",
+            unit_data={"hostname": cache_host, "port": cache_port},
+            app_data={"leader-host": cache_host},
+        )
+        self.harness.add_relation_unit(redis_cache_relation_id, "redis-cache/1")
+        self.harness.update_relation_data(
+            redis_cache_relation_id,
+            "redis-cache/1",
+            {"hostname": "cache-host-1", "port": cache_port},
+        )
+
+        broker_url = self.harness.charm._get_redis_url("redis-broker")
+        cache_url = self.harness.charm._get_redis_url("redis-cache")
+        self.assertEqual(broker_url, f"redis://{broker_host}:{broker_port}")
+        self.assertEqual(cache_url, f"redis://{cache_host}:{cache_port}")
+        broker_host = "broker-host-1"
+        cache_host = "cache-host-1"
+
+        self.harness.update_relation_data(
+            redis_broker_relation_id,
+            "redis-broker",
+            {"leader-host": broker_host},
+        )
+
+        self.harness.update_relation_data(
+            redis_cache_relation_id,
+            "redis-cache",
+            {"leader-host": cache_host},
+        )
+        broker_url = self.harness.charm._get_redis_url("redis-broker")
+        cache_url = self.harness.charm._get_redis_url("redis-cache")
+        self.assertEqual(broker_url, f"redis://{broker_host}:{broker_port}")
+        self.assertEqual(cache_url, f"redis://{cache_host}:{cache_port}")
+
+    def test_redis_ha_old(self):
+        """
+        arrange: charm created
+        act: add redis relation with old redis databag
+        assert: the charm gets the correct url
+        """
+        self.setUp()
+        broker_host = "broker-host"
+        broker_port = "1010"
+        cache_host = "cache-host"
+        cache_port = "1011"
+
+        self.harness.add_relation(
+            "redis-broker",
+            "redis-broker",
+            unit_data={"hostname": broker_host, "port": broker_port},
+        )
+
+        self.harness.add_relation(
+            "redis-cache",
+            "redis-cache",
+            unit_data={"hostname": cache_host, "port": cache_port},
+        )
+        broker_url = self.harness.charm._get_redis_url("redis-broker")
+        cache_url = self.harness.charm._get_redis_url("redis-cache")
+        self.assertEqual(broker_url, f"redis://{broker_host}:{broker_port}")
+        self.assertEqual(cache_url, f"redis://{cache_host}:{cache_port}")
 
     def test_missing_relations(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ commands =
     black {[vars]all_path}
 
 [testenv:lint]
+basepython = py310
 description = Check code against coding style standards
 deps =
     black


### PR DESCRIPTION
Updating the charm according to latest [Redis PR](https://github.com/canonical/redis-k8s-operator/commit/63b8cfa88196a92f913ef05eba7c3fd8f6e8d1a6)

### Overview
Now we get the Url for redis instances from App databag instead of unit databag.

### Rationale
This fixes the issue when Redis is in HA there was a chance the Redis Url used in Indico charm would not have write access to the Redis db.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->