### PR TITLE
 Indico tutorial improvements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
     with:
-      self-hosted-runner: true
+      self-hosted-runner: false
       self-hosted-runner-label: "edge"
   plugins-test:
     name: Specific test for the plugin

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -11,7 +11,7 @@ Through the process, you'll inspect the Kubernetes resources created, verify the
 ## Requirements
 
 - Juju 3 installed.
-- Juju microk8s controller created and active.
+- Juju MicroK8s controller created and active.
 - NGINX Ingress Controller. If you're using [MicroK8s](https://microk8s.io/), this can be done by running the command `microk8s enable ingress`. For more details, see [Addon: Ingress](https://microk8s.io/docs/addon-ingress).
 
 For more information about how to install Juju, see [Get started with Juju](https://juju.is/docs/olm/get-started-with-juju).
@@ -19,7 +19,7 @@ For more information about how to install Juju, see [Get started with Juju](http
 ### Add a Juju model for the tutorial
 
 To manage resources effectively and to separate this tutorial's workload from
-your usual work, we recommend creating a new model using the following command.
+your usual work, create a new model using the following command:
 
 ```
 juju add-model indico-tutorial
@@ -153,7 +153,7 @@ Optional: run `echo "127.0.0.1 indico.local" >> /etc/hosts` to redirect the outp
 After that, visit `http://indico.local` in a browser and you'll be presented with a screen to create an initial admin account.
 
 
-## Cleaning up the Environment
+## Clean up the Environment
 
 Well done! You've successfully completed the Indico tutorial. To remove the
 model environment you created during this tutorial, use the following command.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,4 +1,4 @@
-# Quick guide
+# Deploy the Indico charm for the first time
 
 ## What you’ll do
 
@@ -26,8 +26,8 @@ Deploy the charms:
 
 ```bash
 juju deploy postgresql-k8s --trust
-juju deploy redis-k8s redis-broker
-juju deploy redis-k8s redis-cache
+juju deploy redis-k8s redis-broker --channel=latest/edge
+juju deploy redis-k8s redis-cache --channel=latest/edge
 juju deploy indico
 ```
 
@@ -72,7 +72,7 @@ Note: `database` is the name of the integration. This is needed because establis
 Enable PostgreSQL extensions:
 
 ```bash
-juju config postgresql plugin_pg_trgm_enable=true plugin_unaccent_enable=true
+juju config postgresql-k8s plugin_pg_trgm_enable=true plugin_unaccent_enable=true
 ``` 
 
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -11,10 +11,19 @@ Through the process, you'll inspect the Kubernetes resources created, verify the
 ## Requirements
 
 - Juju 3 installed.
-- Juju controller and model created.
+- Juju microk8s controller created and active.
 - NGINX Ingress Controller. If you're using [MicroK8s](https://microk8s.io/), this can be done by running the command `microk8s enable ingress`. For more details, see [Addon: Ingress](https://microk8s.io/docs/addon-ingress).
 
 For more information about how to install Juju, see [Get started with Juju](https://juju.is/docs/olm/get-started-with-juju).
+
+### Add a Juju model for the tutorial
+
+To manage resources effectively and to separate this tutorial's workload from
+your usual work, we recommend creating a new model using the following command.
+
+```
+juju add-model indico-tutorial
+```
 
 ### Deploy the Indico charm
 
@@ -31,7 +40,7 @@ juju deploy redis-k8s redis-cache --channel=latest/edge
 juju deploy indico
 ```
 
-To see the pod created by the Indico charm, run `kubectl get pods` on a namespace named for the Juju model you've deployed the Indico charm into. The output is similar to the following:
+To see the pod created by the Indico charm, run `kubectl get pods -n indico-tutorial`, where the namespace is the name of the Juju model. The output is similar to the following:
 
 ```bash
 NAME                             READY   STATUS    RESTARTS   AGE
@@ -142,3 +151,13 @@ The default hostname for the Indico application is `indico.local`. To resolve it
 Optional: run `echo "127.0.0.1 indico.local" >> /etc/hosts` to redirect the output of the command `echo` to the end of the file `/etc/hosts`.
 
 After that, visit `http://indico.local` in a browser and you'll be presented with a screen to create an initial admin account.
+
+
+## Cleaning up the Environment
+
+Well done! You've successfully completed the Indico tutorial. To remove the
+model environment you created during this tutorial, use the following command.
+
+```
+juju destroy-model indico-tutorial --no-prompt --destroy-storage=true
+```


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Rename the tutorial title, from "Quick guide" -> "Deploy the Indico charm for the first time".
Added creating and destroy the model in the tutorial.


Also minor fixes:
Use redis in the channel latest/edge, as the stable channel has not been updated since 2021.
Fix typo in command, that was using app name `postgresql` instead of `postgresql-k8s`.



### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->