### PR TITLE
feat/ISD-3500: Bumping indico version

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,6 +1,7 @@
 # go stdlib
 CVE-2024-34156
 CVE-2025-22869
+CVE-2025-22874
 # usr/bin/statsd_exporter
 CVE-2024-24790
 CVE-2023-39325
@@ -27,4 +28,3 @@ CVE-2024-56672 # linux-libc-dev no fix yet
 CVE-2024-57798 # linux-libc-dev no fix yet
 CVE-2024-56595 # linux-libc-dev no fix yet
 CVE-2025-22088 # linux-libc-dev no fix yet
-

--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -24,8 +24,8 @@ parts:
     python-packages:
       - setuptools
       - wheel
-      - indico==3.3.1
-      - indico-plugin-payment-paypal==3.3
+      - indico==3.3.6
+      - indico-plugin-payment-paypal==3.3.2
       - indico-plugin-piwik
       - indico-plugin-storage-s3
       - python3-saml

--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -65,9 +65,9 @@ parts:
       - gtrkiller-statsd-prometheus-exporter/latest/edge
     override-build: |
       craftctl default
-      cd /root/parts/indico/install/lib/python3.12/site-packages/
+      cd $CRAFT_PART_INSTALL/lib/python3.12/site-packages/
       rm -rf lxml* lxml-*.dist-info
-      pip install --target=/root/parts/indico/install/lib/python3.12/site-packages --no-cache-dir --no-binary=lxml lxml==5.3.0
+      pip install --target=$CRAFT_PART_INSTALL/lib/python3.12/site-packages --no-cache-dir --no-binary=lxml lxml==5.3.0
     override-stage: |
       mkdir -p --mode=775 $CRAFT_PART_INSTALL/srv/indico/{archive,cache,custom,etc,log,tmp}
       cp $CRAFT_PART_INSTALL/lib/python3.12/site-packages/indico/web/indico.wsgi $CRAFT_PART_INSTALL/srv/indico/indico.wsgi

--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -65,11 +65,9 @@ parts:
       - gtrkiller-statsd-prometheus-exporter/latest/edge
     override-build: |
       craftctl default
-      source /root/parts/indico/install/bin/activate
-      pip uninstall -y lxml
-      STATIC_DEPS=true pip install lxml==5.3.0
-      # Error here to stop for debugging
-      pip install xyz
+      cd /root/parts/indico/install/lib/python3.12/site-packages/
+      rm -rf lxml* lxml-*.dist-info
+      STATIC_DEPS=true pip install --target=/root/parts/indico/install/lib/python3.12/site-packages --no-cache-dir lxml==5.3.0
     override-stage: |
       mkdir -p --mode=775 $CRAFT_PART_INSTALL/srv/indico/{archive,cache,custom,etc,log,tmp}
       cp $CRAFT_PART_INSTALL/lib/python3.12/site-packages/indico/web/indico.wsgi $CRAFT_PART_INSTALL/srv/indico/indico.wsgi

--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -63,6 +63,13 @@ parts:
     stage-snaps:
       - celery-prometheus-exporter/latest/edge
       - gtrkiller-statsd-prometheus-exporter/latest/edge
+    override-build: |
+      craftctl default
+      source /root/parts/indico/install/bin/activate
+      pip uninstall -y lxml
+      STATIC_DEPS=true pip install lxml==5.3.0
+      # Error here to stop for debugging
+      pip install xyz
     override-stage: |
       mkdir -p --mode=775 $CRAFT_PART_INSTALL/srv/indico/{archive,cache,custom,etc,log,tmp}
       cp $CRAFT_PART_INSTALL/lib/python3.12/site-packages/indico/web/indico.wsgi $CRAFT_PART_INSTALL/srv/indico/indico.wsgi

--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -67,7 +67,7 @@ parts:
       craftctl default
       cd /root/parts/indico/install/lib/python3.12/site-packages/
       rm -rf lxml* lxml-*.dist-info
-      STATIC_DEPS=true pip install --target=/root/parts/indico/install/lib/python3.12/site-packages --no-cache-dir lxml==5.3.0
+      pip install --target=/root/parts/indico/install/lib/python3.12/site-packages --no-cache-dir --no-binary=lxml lxml==5.3.0
     override-stage: |
       mkdir -p --mode=775 $CRAFT_PART_INSTALL/srv/indico/{archive,cache,custom,etc,log,tmp}
       cp $CRAFT_PART_INSTALL/lib/python3.12/site-packages/indico/web/indico.wsgi $CRAFT_PART_INSTALL/srv/indico/indico.wsgi

--- a/nginx_rock/rockcraft.yaml
+++ b/nginx_rock/rockcraft.yaml
@@ -42,7 +42,7 @@ parts:
       mkdir run
   indico-files:
     python-packages:
-      - indico==3.3.1
+      - indico==3.3.6
     build-packages:
       - libpq-dev
     plugin: python

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -83,7 +83,6 @@ async def app_fixture(
             "nginx-ingress-integrator",
             channel="latest/edge",
             revision=133,
-            series="focal",
             trust=True,
         ),
     )
@@ -97,7 +96,6 @@ async def app_fixture(
             f"./{charm}",
             resources=resources,
             application_name=app_name,
-            series="focal",
         )
     else:
         charm = await ops_test.build_charm(".")
@@ -105,7 +103,6 @@ async def app_fixture(
             charm,
             resources=resources,
             application_name=app_name,
-            series="focal",
             config={
                 "external_plugins": "https://github.com/canonical/flask-multipass-saml-groups/releases/download/1.2.1/flask_multipass_saml_groups-1.2.1-py3-none-any.whl"  # noqa: E501 pylint: disable=line-too-long
             },
@@ -182,7 +179,7 @@ async def loki_fixture(ops_test: OpsTest, app: Application):
     """Loki charm used for integration testing."""
     assert ops_test.model
     loki = await ops_test.model.deploy(
-        "loki-k8s", channel="latest/edge", trust=True, revision=97, series="focal"
+        "loki-k8s", channel="latest/edge", trust=True, revision=97
     )
     await ops_test.model.add_relation(app.name, loki.name)
     await ops_test.model.wait_for_idle(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -84,7 +84,7 @@ async def app_fixture(
             channel="latest/edge",
             revision=133,
             trust=True,
-            series="noble",
+            series="focal",
         ),
     )
     resources = {
@@ -97,7 +97,7 @@ async def app_fixture(
             f"./{charm}",
             resources=resources,
             application_name=app_name,
-            series="noble",
+            series="focal",
         )
     else:
         charm = await ops_test.build_charm(".")
@@ -108,7 +108,7 @@ async def app_fixture(
             config={
                 "external_plugins": "https://github.com/canonical/flask-multipass-saml-groups/releases/download/1.2.1/flask_multipass_saml_groups-1.2.1-py3-none-any.whl"  # noqa: E501 pylint: disable=line-too-long
             },
-            series="noble",
+            series="focal",
         )
 
     await asyncio.gather(
@@ -182,7 +182,7 @@ async def loki_fixture(ops_test: OpsTest, app: Application):
     """Loki charm used for integration testing."""
     assert ops_test.model
     loki = await ops_test.model.deploy(
-        "loki-k8s", channel="latest/edge", trust=True, revision=97, series="noble"
+        "loki-k8s", channel="latest/edge", trust=True, revision=97, series="focal"
     )
     await ops_test.model.add_relation(app.name, loki.name)
     await ops_test.model.wait_for_idle(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -84,6 +84,7 @@ async def app_fixture(
             channel="latest/edge",
             revision=133,
             trust=True,
+            series="noble",
         ),
     )
     resources = {
@@ -96,6 +97,7 @@ async def app_fixture(
             f"./{charm}",
             resources=resources,
             application_name=app_name,
+            series="noble",
         )
     else:
         charm = await ops_test.build_charm(".")
@@ -106,6 +108,7 @@ async def app_fixture(
             config={
                 "external_plugins": "https://github.com/canonical/flask-multipass-saml-groups/releases/download/1.2.1/flask_multipass_saml_groups-1.2.1-py3-none-any.whl"  # noqa: E501 pylint: disable=line-too-long
             },
+            series="noble",
         )
 
     await asyncio.gather(
@@ -179,7 +182,7 @@ async def loki_fixture(ops_test: OpsTest, app: Application):
     """Loki charm used for integration testing."""
     assert ops_test.model
     loki = await ops_test.model.deploy(
-        "loki-k8s", channel="latest/edge", trust=True, revision=97
+        "loki-k8s", channel="latest/edge", trust=True, revision=97, series="noble"
     )
     await ops_test.model.add_relation(app.name, loki.name)
     await ops_test.model.wait_for_idle(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -106,7 +106,7 @@ async def app_fixture(
             resources=resources,
             application_name=app_name,
             config={
-                "external_plugins": "https://github.com/canonical/flask-multipass-saml-groups/releases/download/1.2.1/flask_multipass_saml_groups-1.2.1-py3-none-any.whl"  # noqa: E501 pylint: disable=line-too-long
+                "external_plugins": "https://github.com/canonical/flask-multipass-saml-groups/releases/download/1.2.2/flask_multipass_saml_groups-1.2.2-py3-none-any.whl"  # noqa: E501 pylint: disable=line-too-long
             },
             series="focal",
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,9 +87,6 @@ async def app_fixture(
             trust=True,
         ),
     )
-    await ops_test.model.wait_for_idle(
-        apps=["postgresql-k8s"], status="active", raise_on_error=False
-    )
     resources = {
         "indico-image": pytestconfig.getoption("--indico-image"),
         "indico-nginx-image": pytestconfig.getoption("--indico-nginx-image"),
@@ -109,6 +106,9 @@ async def app_fixture(
             resources=resources,
             application_name=app_name,
             series="focal",
+            config={
+                "external_plugins": "https://github.com/canonical/flask-multipass-saml-groups/releases/download/1.2.1/flask_multipass_saml_groups-1.2.1-py3-none-any.whl"  # noqa: E501 pylint: disable=line-too-long
+            },
         )
 
     await asyncio.gather(
@@ -117,13 +117,16 @@ async def app_fixture(
         ops_test.model.add_relation(f"{app_name}:redis-cache", "redis-cache"),
         ops_test.model.add_relation(app_name, "nginx-ingress-integrator"),
     )
-    await ops_test.model.wait_for_idle(status="active", raise_on_error=False)
-    # Install saml_groups plugin
-    # Disabling line-too-long lint since we are installing the plugin via gh release
-    await application.set_config(
-        {
-            "external_plugins": "https://github.com/canonical/flask-multipass-saml-groups/releases/download/1.2.1/flask_multipass_saml_groups-1.2.1-py3-none-any.whl"  # noqa: E501 pylint: disable=line-too-long
-        }
+    await ops_test.model.wait_for_idle(
+        apps=[
+            application.name,
+            "postgresql-k8s",
+            "redis-broker",
+            "redis-cache",
+            "nginx-ingress-integrator",
+        ],
+        status="active",
+        raise_on_error=True,
     )
     yield application
 
@@ -141,7 +144,7 @@ async def saml_integrator_fixture(ops_test: OpsTest, app: Application):
     )
     await ops_test.model.add_relation(app.name, saml_integrator.name)
     await ops_test.model.wait_for_idle(
-        apps=[saml_integrator.name, app.name], status="active", raise_on_error=False
+        apps=[saml_integrator.name, app.name], status="active", raise_on_error=True
     )
     yield saml_integrator
 
@@ -165,11 +168,11 @@ async def s3_integrator_fixture(ops_test: OpsTest, app: Application):
     )
     await action_sync_s3_credentials.wait()
     await ops_test.model.wait_for_idle(
-        apps=[s3_integrator.name], status="active", raise_on_error=False
+        apps=[s3_integrator.name], status="active", raise_on_error=True
     )
     await ops_test.model.add_relation(app.name, s3_integrator.name)
     await ops_test.model.wait_for_idle(
-        apps=[s3_integrator.name, app.name], status="active", raise_on_error=False
+        apps=[s3_integrator.name, app.name], status="active", raise_on_error=True
     )
     yield s3_integrator
 
@@ -183,6 +186,6 @@ async def loki_fixture(ops_test: OpsTest, app: Application):
     )
     await ops_test.model.add_relation(app.name, loki.name)
     await ops_test.model.wait_for_idle(
-        apps=[loki.name, app.name], status="active", raise_on_error=False
+        apps=[loki.name, app.name], status="active", raise_on_error=True
     )
     yield loki

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -28,7 +28,6 @@ async def test_active(app: Application):
     """
     # Application actually does have units
     assert app.units[0].workload_status == ActiveStatus.name  # type: ignore
-    assert False
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -28,6 +28,7 @@ async def test_active(app: Application):
     """
     # Application actually does have units
     assert app.units[0].workload_status == ActiveStatus.name  # type: ignore
+    assert False
 
 
 @pytest.mark.asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ deps =
     flake8-docstrings>=1.6.0
     flake8-docstrings-complete>=1.0.3
     flake8-test-docs>=1.0
-    indico==3.3.1
+    indico==3.3.6
     isort
     mypy
     pep8-naming


### PR DESCRIPTION
Applicable ticket: ISD-3500

### Overview

Bumping the indico version from 3.3.1 to latest ( 3.3.6 ). This bumps the plug-in versions too.

### Rationale

Indico released new version with security updates. This change ensures we have them.

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->