### PR TITLE
feat: Pinning boto3 version as the higher versions break for s3 storage

### DIFF
--- a/indico_rock/rockcraft.yaml
+++ b/indico_rock/rockcraft.yaml
@@ -25,6 +25,7 @@ parts:
       - setuptools
       - wheel
       - indico==3.3.6
+      - boto3==1.35.99 # Due to issue https://github.com/boto/boto3/issues/4398
       - indico-plugin-payment-paypal==3.3.2
       - indico-plugin-piwik
       - indico-plugin-storage-s3

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -182,7 +182,7 @@ async def loki_fixture(ops_test: OpsTest, app: Application):
     """Loki charm used for integration testing."""
     assert ops_test.model
     loki = await ops_test.model.deploy(
-        "loki-k8s", channel="latest/edge", trust=True, revision=97, series="focal"
+        "loki-k8s", channel="1/edge", trust=True, revision=97, series="focal"
     )
     await ops_test.model.add_relation(app.name, loki.name)
     await ops_test.model.wait_for_idle(


### PR DESCRIPTION
### Overview

Pinning the boto3 version to 1.35.99

### Rationale

With boto3 1.36.00, there is a new checksum behavior that breaks the S3 storage in our deployment. Related issue: https://github.com/boto/boto3/issues/4398

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->