### PR TITLE
Add Indico terraform module

### DIFF
--- a/.github/workflows/test_terraform_files.yaml
+++ b/.github/workflows/test_terraform_files.yaml
@@ -1,0 +1,52 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: Test terraform files
+
+on:
+  pull_request:
+    paths:
+      - 'terraform/**'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate terraform configuration files
+    runs-on: ubuntu-latest
+    env:
+      WORKING_DIR: 'terraform'
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5.0.0
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3.1.2
+
+      - name: Run terraform fmt
+        run: terraform fmt -check -recursive
+        working-directory: ${{env.WORKING_DIR}}
+
+      - name: Setup Tflint
+        uses: terraform-linters/setup-tflint@v5.0.0
+        with:
+          tflint_wrapper_enabled: true
+
+      - name: Run tflint
+        run: |
+          tflint --version
+          tflint --init
+          tflint -f compact --recursive
+        working-directory: ${{env.WORKING_DIR}}
+
+  required_status_checks:
+    name: Required Terraform Validate Status Checks
+    runs-on: ubuntu-latest
+    needs:
+      - validate
+    if: always() && !cancelled()
+    timeout-minutes: 5
+    steps:
+      - run: |
+          [ '${{ needs.validate.result }}' = 'success' ] || (echo validate failed && false)

--- a/.github/workflows/test_terraform_module.yaml
+++ b/.github/workflows/test_terraform_module.yaml
@@ -1,0 +1,51 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: Run Terraform tests
+
+on:
+  pull_request:
+    paths:
+      - 'terraform/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test-terraform:
+    name: Test Terraform with Juju
+    runs-on: ubuntu-latest
+    env:
+      WORKING_DIR: 'terraform/tests'
+    steps:
+    - uses: actions/checkout@@v4.2.2
+    - uses: charmed-kubernetes/actions-operator@main
+      with:
+        provider: "microk8s"
+    - name: Prepare juju tf provider environment
+      run: |
+        CONTROLLER=$(juju whoami | yq .Controller)
+        JUJU_CONTROLLER_ADDRESSES="$(juju show-controller | yq '.[$CONTROLLER]'.details.\"api-endpoints\" | tr -d "[]' "|tr -d '"'|tr -d '\n')"
+        JUJU_USERNAME="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.user|tr -d '"')"
+        JUJU_PASSWORD="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password|tr -d '"')"
+
+        echo "JUJU_CONTROLLER_ADDRESSES=$JUJU_CONTROLLER_ADDRESSES" >> "$GITHUB_ENV"
+        echo "JUJU_USERNAME=$JUJU_USERNAME" >> "$GITHUB_ENV"
+        echo "JUJU_PASSWORD=$JUJU_PASSWORD" >> "$GITHUB_ENV"
+        {
+          echo 'JUJU_CA_CERT<<EOF'
+          juju show-controller $(echo $CONTROLLER|tr -d '"') | yq '.[$CONTROLLER]'.details.\"ca-cert\"|tr -d '"'
+          echo EOF
+        } >> "$GITHUB_ENV"
+    - uses: hashicorp/setup-terraform@v3.1.2
+    - run: terraform init
+      working-directory: ${{env.WORKING_DIR}}
+    - run: terraform plan -out=tfplan
+      working-directory: ${{env.WORKING_DIR}}
+    - run: terraform show tfplan
+      working-directory: ${{env.WORKING_DIR}}
+    - run: |
+        juju add-model prod-chat-example
+        set -e  # Exit on error
+        terraform test || { echo "Terraform test failed"; exit 1; }
+      working-directory: ${{env.WORKING_DIR}}

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,15 @@
   "extends": [
     "config:base"
   ],
+  "customDatasources": {
+        "charmhub": {
+            "defaultRegistryUrlTemplate": "https://api.charmhub.io/v2/charms/info/{{packageName}}?fields=channel-map",
+            "format": "json",
+            "transformTemplates": [
+                "{\"releases\": [{\"version\": $string($$.(`channel-map`[channel.risk = 'edge' and channel.track = 'latest' and channel.base.architecture = 'amd64' and channel.base.channel = '20.04'].revision.revision))}]}"
+            ]
+        }
+    },
   "regexManagers": [
     {
       "fileMatch": ["(^|/)rockcraft.yaml$"],
@@ -31,6 +40,13 @@
       "depNameTemplate": "indico/indico",
       "versioningTemplate": "semver-coerced"
     },
+    {
+      "fileMatch": ["(^|/)main.tftest.hcl$"],
+      "matchStrings": ["# renovate: depName=\"(?<packageName>[^\"]+)\"\\s*\\n\\s*(?<fieldName>[a-zA-Z0-9_]+)\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
+      "versioningTemplate": "semver-coerced",
+      "datasourceTemplate": "custom.charmhub",
+      "matchStringsStrategy": "recursive"
+    }
   ],
   "packageRules": [
     {
@@ -41,9 +57,15 @@
       "pinDigests": true
     },
     {
-      "matchFiles": ["rockcraft.yaml"],
-      "matchUpdateTypes": ["major", "minor", "patch"],
-      "enabled": false
+      "matchDatasources": [
+          "custom.charmhub"
+      ],
+      "enabled": true
+    },
+    {
+      "matchDatasources": ["terraform-provider"],
+      "matchPackageNames": ["juju/juju"],
+      "enabled": true
     }
   ]
 }

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -1,0 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+rule "terraform_required_version" {
+  enabled = false
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,42 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 0.21.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 0.21.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [juju_application.indico](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the application in the Juju model. | `string` | `"synapse"` | no |
+| <a name="input_base"></a> [base](#input\_base) | The operating system on which to deploy | `string` | `"ubuntu@20.04"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | The channel to use when deploying a charm. | `string` | `"latest/stable"` | no |
+| <a name="input_config"></a> [config](#input\_config) | Application config. | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | Juju constraints to apply for this application. | `string` | `""` | no |
+| <a name="input_model"></a> [model](#input\_model) | Reference to a `juju_model`. | `string` | `""` | no |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm. | `number` | `null` | no |
+| <a name="input_storage"></a> [storage](#input\_storage) | Map of storage used by the application. | `map(string)` | `{}` | no |
+| <a name="input_units"></a> [units](#input\_units) | Number of units to deploy. | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | Name of the deployed application. |
+| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,19 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "indico" {
+  name  = var.app_name
+  model = var.model
+
+  charm {
+    name     = "indico"
+    base     = var.base
+    channel  = var.channel
+    revision = var.revision
+  }
+
+  config             = var.config
+  constraints        = var.constraints
+  units              = var.units
+  storage_directives = var.storage
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.indico.name
+}
+
+output "endpoints" {
+  value = {
+    grafana_dashboard = "grafana-dashboard"
+    metrics_endpoint  = "metrics-endpoint"
+    database          = "database"
+    nginx_route       = "nginx-route"
+    redis_broker      = "redis-broker"
+    redis_cache       = "redis-cache"
+    s3                = "s3"
+    saml              = "saml"
+    smtp_legacy       = "smtp-legacy"
+    logging           = "logging"
+  }
+}

--- a/terraform/tests/.tflint.hcl
+++ b/terraform/tests/.tflint.hcl
@@ -1,0 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+rule "terraform_required_version" {
+  enabled = false
+}

--- a/terraform/tests/main.tf
+++ b/terraform/tests/main.tf
@@ -1,0 +1,34 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "channel" {
+  description = "The channel to use when deploying a charm."
+  type        = string
+  default     = "latest/edge"
+}
+
+variable "revision" {
+  description = "Revision number of the charm."
+  type        = number
+  default     = null
+}
+
+terraform {
+  required_providers {
+    juju = {
+      version = "~> 0.21.1"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+module "indico" {
+  source      = "./.."
+  app_name    = "indico"
+  channel     = var.channel
+  model       = "prod-events-example"
+  revision    = var.revision
+  constraints = "arch=amd64"
+}

--- a/terraform/tests/main.tftest.hcl
+++ b/terraform/tests/main.tftest.hcl
@@ -1,0 +1,15 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variables {
+  channel = "latest/edge"
+  # renovate: depName="indico"
+  revision = 263
+}
+
+run "basic_deploy" {
+  assert {
+    condition     = module.indico.app_name == "indico"
+    error_message = "Indico app_name did not match expected"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,56 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "synapse"
+}
+
+variable "base" {
+  description = "The operating system on which to deploy"
+  type        = string
+  default     = "ubuntu@20.04"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying a charm."
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "config" {
+  description = "Application config."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = ""
+}
+
+variable "model" {
+  description = "Reference to a `juju_model`."
+  type        = string
+  default     = ""
+}
+
+variable "revision" {
+  description = "Revision number of the charm."
+  type        = number
+  default     = null
+}
+
+variable "storage" {
+  description = "Map of storage used by the application."
+  type        = map(string)
+  default     = {}
+}
+
+variable "units" {
+  description = "Number of units to deploy."
+  type        = number
+  default     = 1
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,11 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.21.1"
+    }
+  }
+}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add Indico terraform module, tests and changes Renovate for updating the test and the provider versions.

### Rationale

Provide a terraform module as per the spec CC006.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
No changes in the charm to be added to the Changelog.