### PR TITLE
feat(docs): Evolve and standardize the documentation workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,12 @@
+name: Documentation
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  docs-checks:
+    uses: canonical/operator-workflows/.github/workflows/docs.yaml@main
+    secrets: inherit
+

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,4 +9,6 @@ jobs:
   docs-checks:
     uses: canonical/operator-workflows/.github/workflows/docs.yaml@main
     secrets: inherit
+    with:
+      vale-files: '["docs/**/*.md", "README.md"]'
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,16 @@ __pycache__/
 .mypy_cache
 *.egg-info/
 */*.rock
+
+# BEGIN VALE WORKFLOW IGNORE
+.vale/styles/*
+!.vale/styles/local
+!.vale/styles/config/
+
+.vale/styles/config/*
+!.vale/styles/config/vocabularies/
+
+.vale/styles/config/vocabularies/*
+!.vale/styles/config/vocabularies/local
+# END VALE WORKFLOW IGNORE
+

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,12 @@
+; Copyright 2025 Canonical Ltd.
+; See LICENSE file for licensing details.
+
+StylesPath = .vale/styles
+
+Packages = https://github.com/canonical/platform-engineering-vale-package/releases/download/latest/pfe-vale.zip
+
+Vocab = PFE, local
+
+[*]
+BasedOnStyles = PFE
+

--- a/.vale/styles/config/vocabularies/local/accept.txt
+++ b/.vale/styles/config/vocabularies/local/accept.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/.vale/styles/config/vocabularies/local/accept.txt
+++ b/.vale/styles/config/vocabularies/local/accept.txt
@@ -1,1 +1,2 @@
-placeholder
+Addon
+rclone

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Top-level Makefile
+# Delegates targets to Makefile.docs
+
+# ==============================================================================
+# Macros
+# ==============================================================================
+
+# Colors
+NO_COLOR=\033[0m
+CYAN_COLOR=\033[0;36m
+YELLOW_COLOR=\033[0;93m
+RED_COLOR=\033[0;91m
+
+msg = @printf '$(CYAN_COLOR)$(1)$(NO_COLOR)\n'
+errmsg = @printf '$(RED_COLOR)Error: $(1)$(NO_COLOR)\n' && exit 1
+
+# ==============================================================================
+# Core
+# ==============================================================================
+
+include Makefile.docs
+
+.PHONY: help 
+help: _list-targets ## Prints all available targets
+
+.PHONY: _list-targets
+_list-targets: ## This collects and prints all targets, ignore internal commands
+	$(call msg,Available targets:)
+	@awk -F'[:#]' '                                               \
+		/^[a-zA-Z0-9._-]+:([^=]|$$)/ {                            \
+			target = $$1;                                         \
+			comment = "";                                         \
+			if (match($$0, /## .*/))                              \
+				comment = substr($$0, RSTART + 3);                \
+			if (target != ".PHONY" && target !~ /^_/ && !seen[target]++) \
+				printf "  make %-20s $(YELLOW_COLOR)# %s$(NO_COLOR)\n", target, comment;    \
+		}' $(MAKEFILE_LIST) | sort
+

--- a/Makefile.docs
+++ b/Makefile.docs
@@ -1,0 +1,75 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Minimal makefile for documentation
+#
+
+# Vale settings
+VALE_DIR ?= .vale
+PRAECEPTA_CONFIG 	?= .vale.ini
+DOCS_FILES 	?= docs/ README.md CONTRIBUTING.md
+
+HAS_VALE			:= $(shell command -v vale;)
+HAS_LYCHEE			:= $(shell command -v lychee;)
+
+# ==============================================================================
+# Docs Targets
+# ==============================================================================
+
+.PHONY: docs-check
+docs-check: vale lychee ## Run all Docs checks
+
+.PHONY: docs-clean
+docs-clean: vale-clean
+
+# ==============================================================================
+# Dependency Check Targets
+# ==============================================================================
+
+.PHONY: .check-vale
+.check-vale:
+ifndef HAS_VALE
+	$(call errmsg,'vale' is not installed. Please install it first) \
+	exit 1;
+endif
+
+.PHONY: .check-lychee
+.check-lychee:
+ifndef HAS_LYCHEE
+	$(call errmsg,'lychee' is not installed. Please install it first) \
+	exit 1;
+endif
+
+
+# ==============================================================================
+# Main Vale Targets
+# ==============================================================================
+
+.PHONY: vale-sync
+vale-sync: ## Download and install external Vale configuration sources
+	$(call msg,--- Syncing Vale styles... ---)
+	@vale sync
+
+.PHONY: vale
+vale: .check-vale vale-sync ## Run Vale checks on docs
+	$(call msg,--- Running Vale checks on "$(DOCS_FILES)"... ---)
+	@vale --config=$(PRAECEPTA_CONFIG) $(DOCS_FILES)
+
+# ==============================================================================
+# Main Lychee Targets
+# ==============================================================================
+
+.PHONY: lychee
+lychee: .check-lychee ## Run Lychee checks on docs
+	$(call msg,--- Running lychee checks on "$(LYCHEE_DOCS_FILES)"... ---)
+	@lychee $(DOCS_FILES)
+
+# ==============================================================================
+# Helper Targets
+# ==============================================================================
+
+.PHONY: vale-clean
+vale-clean:
+	$(call msg,--- Cleaning downloaded packages and ignored files from "$(VALE_DIR)"... ---)
+	@git clean -dfX $(VALE_DIR)
+

--- a/Makefile.docs
+++ b/Makefile.docs
@@ -7,7 +7,7 @@
 # Vale settings
 VALE_DIR ?= .vale
 PRAECEPTA_CONFIG 	?= .vale.ini
-DOCS_FILES 	?= docs/ README.md CONTRIBUTING.md
+DOCS_FILES 	?= docs/ README.md 
 
 HAS_VALE			:= $(shell command -v vale;)
 HAS_LYCHEE			:= $(shell command -v lychee;)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Promote charm](https://github.com/canonical/indico-operator/actions/workflows/promote_charm.yaml/badge.svg)](https://github.com/canonical/indico-operator/actions/workflows/promote_charm.yaml)
 [![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
 
-# Indico Operator
+# Indico operator
 
 A Juju charm deploying and managing Indico on Kubernetes. Indico is an
 open-source tool for event organisation, archival and collaboration. It allows for deployment on
@@ -26,9 +26,9 @@ You can follow the tutorial [here](https://charmhub.io/indico/docs/tutorial).
 ### Basic operations
 
 The following actions are available for this charm:
-  - refresh-external-resources: refresh the external resources (e.g. S3 bucket)
-  - add-admmin: add an admin user
-  - anonymize-user: anonymize a user
+  - `refresh-external-resources`: refresh the external resources (e.g. S3 bucket)
+  - `add-admmin`: add an admin user
+  - `anonymize-user`: anonymize a user
 
 You can check out the [full list of actions here](https://charmhub.io/indico/actions).
 
@@ -38,7 +38,7 @@ This charm can be integrated with other Juju charms and services:
 
   - [Redis](https://charmhub.io/redis-k8s): Redis is an open source (BSD licensed), in-memory data structure store, used as a database, cache and message broker.
   - [S3](https://charmhub.io/s3-integrator): Amazon Simple Storage Service (Amazon S3) is an object storage service that provides secure, durable, highly available storage with massive scalability and low latency.
-  - [Postgresql](https://charmhub.io/postgresql-k8s): PostgreSQL is a powerful, open source object-relational database system. It has more than 15 years of active development and a proven architecture that has earned it a strong reputation for reliability, data integrity, and correctness.
+  - [PostgreSQL](https://charmhub.io/postgresql-k8s): PostgreSQL is a powerful, open source object-relational database system. It has more than 15 years of active development and a proven architecture that has earned it a strong reputation for reliability, data integrity, and correctness.
 
   and much more. You can find the full list of integrations [here](https://charmhub.io/indico/integrations).
 

--- a/docs/how-to/configure-a-proxy.md
+++ b/docs/how-to/configure-a-proxy.md
@@ -1,3 +1,3 @@
 # How to configure a proxy
 
-This charm supports several operations that require access to external resources, such as customization or plugins installation, so your environment may not be able to reach those URLs unless through a proxy. The proxy can be configured via the [juju model configuration](https://juju.is/docs/juju/manage-models#heading--configure-a-model) setting the [HTTP proxy keys](https://juju.is/docs/juju/list-of-model-configuration-keys).
+This charm supports several operations that require access to external resources, such as customization or plugins installation, so your environment may not be able to reach those URLs unless through a proxy. The proxy can be configured via the [Juju model configuration](https://documentation.ubuntu.com/juju/3.6/howto/manage-models/#heading--configure-a-model) setting the [HTTP proxy keys](https://documentation.ubuntu.com/juju/3.6/reference/configuration/list-of-model-configuration-keys/).

--- a/docs/how-to/configure-s3.md
+++ b/docs/how-to/configure-s3.md
@@ -2,4 +2,4 @@
 
 An S3 bucket can be leveraged to serve the static content uploaded to Indico, potentially improving performance. Moreover, it is required when scaling the charm to serve the uploaded files.
 
-To configure Indico's S3 integration you'll have to deploy the [S3 Integrator charm](https://charmhub.io/s3-integrator/docs/tutorial-getting-started) and integrate it with Indico by running `juju integrate indico s3-integrator`.
+To configure Indico's S3 integration you'll have to deploy the [S3 Integrator charm](https://charmhub.io/s3-integrator) and integrate it with Indico by running `juju integrate indico s3-integrator`.

--- a/docs/how-to/configure-the-external-hostname.md
+++ b/docs/how-to/configure-the-external-hostname.md
@@ -14,4 +14,4 @@ juju trust nginx-ingress-integrator --scope cluster # if RBAC is enabled
 juju integrate nginx-ingress-integrator indico
 ```
 
-For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/indico/configure).
+For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/indico/configurations).

--- a/docs/how-to/contribute.md
+++ b/docs/how-to/contribute.md
@@ -8,16 +8,15 @@ This document explains the processes and practices recommended for contributing 
 - Generally, before developing enhancements to this charm, you should consider [opening an issue
   ](https://github.com/canonical/indico-operator/issues) explaining your use case.
 - If you would like to chat with us about your use-cases or proposed implementation, you can reach
-  us at [Canonical Mattermost public channel](https://chat.charmhub.io/charmhub/channels/charm-dev)
+  us at [Canonical Matrix public channel](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
   or [Discourse](https://discourse.charmhub.io/).
-- Familiarising yourself with the [Charmed Operator Framework](https://juju.is/docs/sdk) library
+- Familiarising yourself with the [Juju documentation](https://documentation.ubuntu.com/juju/3.6/)
   will help you a lot when working on new features or bug fixes.
 - All enhancements require review before being merged. Code review typically examines
   - code quality
   - test coverage
   - user experience for Juju operators of this charm.
 - Please help us out in ensuring easy to review branches by rebasing your pull request branch onto the `main` branch. This also avoids merge commits and creates a linear Git commit history.
-- Please generate src documentation for every commit. See the section below for more details.
 
 ## Developing
 
@@ -36,7 +35,7 @@ source .tox/unit/bin/activate
 
 ### Testing
 
-Note that the [indico](indico_rock/rockcraft.yaml) and [indico nginx](indico_nginx_rock/rockcraft.yaml) images need to be built and pushed to microk8s for the tests to run. They should be tagged as `localhost:32000/indico:latest` and `localhost:32000/indico-nginx:latest` so that Kubernetes knows how to pull them from the microk8s repository. Note that the microk8s registry needs to be enabled using `microk8s enable registry`. More details regarding the OCI images below. The following commands can then be used to run the tests:
+Note that the [indico](https://github.com/canonical/indico-operator/blob/main/indico_rock/rockcraft.yaml) and [indico nginx](https://github.com/canonical/indico-operator/blob/main/nginx_rock/rockcraft.yaml) images need to be built and pushed to MicroK8s for the tests to run. They should be tagged as `localhost:32000/indico:latest` and `localhost:32000/indico-nginx:latest` so that Kubernetes knows how to pull them from the MicroK8s repository. Note that the MicroK8s registry needs to be enabled using `microk8s enable registry`. More details regarding the OCI images below. The following commands can then be used to run the tests:
 
 * `tox`: Runs all of the basic checks (`lint`, `unit`, `static`, and `coverage-report`).
 * `tox -e fmt`: Runs formatting using `black` and `isort`.
@@ -44,15 +43,6 @@ Note that the [indico](indico_rock/rockcraft.yaml) and [indico nginx](indico_ngi
 * `tox -e static`: Runs other checks such as `bandit` for security issues.
 * `tox -e unit`: Runs the unit tests.
 * `tox -e integration`: Runs the integration tests.
-
-### Generating src docs for every commit
-
-Run the following command:
-
-```bash
-echo -e "tox -e src-docs\ngit add src-docs\n" >> .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
-```
 
 ## Build charm
 
@@ -90,4 +80,4 @@ juju deploy ./indico_ubuntu-20.04-amd64.charm \
 
 ## Canonical contributor agreement
 
-Canonical welcomes contributions to the Indico Operator. Please check out our [contributor agreement](https://ubuntu.com/legal/contributors) if you're interested in contributing to the solution.
+Canonical welcomes contributions to the Indico Operator. Please check out our [contributor agreement](https://canonical.com/legal/contributors) if you're interested in contributing to the solution.

--- a/docs/how-to/customize-theme.md
+++ b/docs/how-to/customize-theme.md
@@ -6,4 +6,4 @@ If you wish to apply a set of customisation files, set the configuration option 
 
 The theme changes can be pulled by running the [refresh-external-resources action](https://charmhub.io/indico/actions#refresh-external-resources).
 
-For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/indico/configure).
+For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/indico/configurations).

--- a/docs/how-to/install-plugins.md
+++ b/docs/how-to/install-plugins.md
@@ -12,4 +12,4 @@ juju config [charm_name] external_plugins=git+https://github.com/indico/indico-p
 
 The installed plugins can be upgraded by running the [refresh-external-resources action](https://charmhub.io/indico/actions#refresh-external-resources). Note that the upgrade won't take place if the published version hasn't changed.
 
-For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/indico/configure).
+For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/indico/configurations).

--- a/docs/how-to/redeploy.md
+++ b/docs/how-to/redeploy.md
@@ -4,7 +4,7 @@ This guide provides the necessary steps for migrating an existing Indico instanc
 
 ## Migrate the database
 
-Follow the instructions in [the charm migration documentation](https://charmhub.io/postgresql-k8s/docs/h-migrate-cluster-via-restore) to migrate the content of the Indico PostgreSQL database.
+Follow the instructions in [the charm migration documentation](https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/14/how-to/back-up-and-restore/migrate-a-cluster/) to migrate the content of the Indico PostgreSQL database.
 
 ## Migrate files stored in S3
 
@@ -14,4 +14,4 @@ If your media files are stored in an S3 bucket, you have two options:
 2. Use tools like [rclone](https://rclone.org) to copy files from the old
    storage bucket to a new bucket for the new deployment.
 
-If the files are not stored in S3, they are not expected to persist across unit restarts or to be available in multiple units. However, it is still possible to copy them to the new charm instance using [juju scp](https://juju.is/docs/juju/juju-scp).
+If the files are not stored in S3, they are not expected to persist across unit restarts or to be available in multiple units. However, it is still possible to copy them to the new charm instance using [`juju scp`](https://juju.is/docs/juju/juju-scp).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Indico operator
 
-A [Juju](https://juju.is/) [charm](https://juju.is/docs/olm/charmed-operators) deploying and managing [Indico](https://getindico.io/) on Kubernetes. Indico is an open-source tool for event organisation, archival, and collaboration.
+A [Juju](https://juju.is/) [charm](https://documentation.ubuntu.com/juju/3.6/reference/charm/) deploying and managing [Indico](https://getindico.io/) on Kubernetes. Indico is an open-source tool for event organisation, archival, and collaboration.
 
 Like any Juju charm, this charm supports one-line deployment, configuration, integration, scaling, and more. For Indico, this includes:
 - Integrations with SSO
@@ -32,7 +32,7 @@ The Indico Operator is a member of the Ubuntu family. It's an open-source projec
 - [Code of conduct](https://ubuntu.com/community/code-of-conduct)
 - [Get support](https://discourse.charmhub.io/)
 - [Join our online chat](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
-- [Contribute](Contribute)
+- [Contribute](https://charmhub.io/indico/docs/how-to-contribute)
 
 Thinking about using the Indico Operator for your next project? [Get in touch](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)!
 

--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -2,4 +2,4 @@
 
 See [Actions](https://charmhub.io/indico/actions).
 
-> Read more about actions in the Juju docs: [Action](https://juju.is/docs/juju/action)
+> Read more about actions in the Juju docs: [Action](https://documentation.ubuntu.com/juju/3.6/reference/action/)

--- a/docs/reference/configurations.md
+++ b/docs/reference/configurations.md
@@ -2,4 +2,4 @@
 
 See [Configurations](https://charmhub.io/indico/configure).
 
-> Read more about configurations in the Juju docs: [Configuration](https://juju.is/docs/juju/configuration)
+> Read more about configurations in the Juju docs: [Configuration](https://documentation.ubuntu.com/juju/3.6/reference/configuration/)

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -2,54 +2,54 @@
 
 An overview of the different relation endpoints.
 
-### Db
+### `db`
 
 _Interface_: pgsql  
-_Supported charms_: [postgresql-k8s](https://charmhub.io/postgresql-k8s), [postgresql](https://charmhub.io/postgresql)
+_Supported charms_: [`postgresql-k8s`](https://charmhub.io/postgresql-k8s), [`postgresql`](https://charmhub.io/postgresql)
 
-Database integration is a required relation for the indico charm to supply structured data
+Database integration is a required relation for the Indico charm to supply structured data
 storage for Indico.
 
-Example db integrate command: 
+Example `db` integrate command: 
 
 ```
 juju integrate indico postgresql-k8s:db
 ```
 
-### Redis
+### `redis`
 
 _Interface_: redis  
 _Supported charms_: [redis-k8s](https://charmhub.io/redis-k8s)
 
-Redis integration is a required relation for the indico charm to supply caching capabilities and
+Redis integration is a required relation for the Indico charm to supply caching capabilities and
 a message broker to interface with Celery. As such, two instances are needed, `redis-cache` and 
 `redis-broker`.
 
-Example db integrate commands: 
+Example `redis` integrate commands: 
 ```
 juju integrate redis-cache indico 
 juju integrate redis-broker indico
 ```
 
-### Ingress
+### `ingress`
 
 _Interface_: ingress  
 _Supported charms_: [nginx-ingress-integrator](https://charmhub.io/nginx-ingress-integrator)
 
-Ingress manages external http/https access to services in a kubernetes cluster.
+Ingress manages external HTTP/HTTPS access to services in a Kubernetes cluster.
 Ingress relation through [nginx-ingress-integrator](https://charmhub.io/nginx-ingress-integrator)
 charm enables additional `blog_hostname` and `use_nginx_ingress_modesec` configurations. Note that the
-kubernetes cluster must already have an nginx ingress controller already deployed. Documentation to
-enable ingress in microk8s can be found [here](https://microk8s.io/docs/addon-ingress).
+Kubernetes cluster must already have an nginx ingress controller already deployed. Documentation to
+enable ingress in MicroK8s can be found [here](https://microk8s.io/docs/addon-ingress).
 
-Example ingress integrate command: 
+Example `ingress` integrate command: 
 ```
 juju integrate indico nginx-ingress-integrator
 ```
 
-### Metrics-endpoint
+### `metrics-endpoint`
 
-_Interface_: [prometheus_scrape](https://charmhub.io/interfaces/prometheus_scrape-v0)  
+_Interface_: [prometheus_scrape](https://charmhub.io/interfaces/prometheus_scrape)  
 _Supported charms_: [prometheus-k8s](https://charmhub.io/prometheus-k8s)
 
 Metrics-endpoint relation allows scraping the `/metrics` endpoint provided by apache-exporter sidecar
@@ -58,12 +58,12 @@ apache’s `/server-status` route is not exposed and can only be accessed from w
 Kubernetes pod. The metrics are exposed in the [open metrics format](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#data-model) and will only be scraped by Prometheus once the relation becomes active. For more
 information about the metrics exposed, please refer to the apache-exporter [documentation](https://github.com/Lusitaniae/apache_exporter#collectors).
 
-Metrics-endpoint integrate command: 
+Example `metrics-endpoint` integrate command: 
 ```
 juju integrate indico prometheus-k8s
 ```
 
-### Grafana-dashboard
+### `grafana-dashboard`
 
 _Interface_: grafana-dashboard  
 _Supported charms_: [grafana-k8s](https://charmhub.io/grafana-k8s)
@@ -74,7 +74,7 @@ be found at `/src/grafana_dashboards/indico.json`. In Grafana UI, it can be foun
 Operator Overview" under the General section of the dashboard browser (`/dashboards`). Modifications
 to the dashboard can be made but will not be persisted upon restart/redeployment of the charm.
 
-Grafana-Prometheus integrate command: 
+Example Grafana-Prometheus integrate command: 
 ```
 juju integrate grafana-k8s:grafana-source prometheus-k8s:grafana-source
 ```  

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -9,13 +9,13 @@
 Through the process, you'll inspect the Kubernetes resources created, verify the workload state, and log in to your Indico instance.
 
 ## Requirements
-- A working station, e.g., a laptop, with amd64 architecture.
+- A working station, e.g., a laptop, with AMD64 architecture.
 <!-- vale off -->
-- Juju 3 installed and bootstrapped to a MicroK8s controller. You can accomplish this process by using a Multipass VM as outlined in this guide: [Set up / Tear down your test environment](https://juju.is/docs/juju/set-up--tear-down-your-test-environment)
+- Juju 3 installed and bootstrapped to a MicroK8s controller. You can accomplish this process by using a Multipass VM as outlined in this guide: [Set up your test environment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development/)
 <!-- vale on -->
 - NGINX Ingress Controller. If you're using [MicroK8s](https://microk8s.io/), this can be done by running the command `microk8s enable ingress`. For more details, see [Addon: Ingress](https://microk8s.io/docs/addon-ingress).
 
-For more information about how to install Juju, see [Get started with Juju](https://juju.is/docs/olm/get-started-with-juju).
+For more information about how to install Juju, see [Get started with Juju](https://documentation.ubuntu.com/juju/3.6/tutorial/).
 
 :warning: When using a Multipass VM, make sure to replace `127.0.0.1` IP addresses with the
 VM IP in steps that assume you're running locally. To get the IP address of the
@@ -41,7 +41,7 @@ juju add-model indico-tutorial
 
 Since Indico requires connections to PostgreSQL and Redis, you'll deploy them too. For more information, see [Charm Architecture](https://charmhub.io/indico/docs/explanation-charm-architecture).
 
-Redis is deployed twice because one is for the broker and the other for the cache. To do this, the `juju deploy` command accepts an extra argument with the custom application name. See more details in [Override the name of a deployed application](https://juju.is/docs/olm/deploy-a-charm-from-charmhub#heading--override-the-name-of-a-deployed-application).
+Redis is deployed twice because one is for the broker and the other for the cache. To do this, the `juju deploy` command accepts an extra argument with the custom application name. See more details in [`juju deploy`](https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/deploy/).
 
 Deploy the charms:
 
@@ -59,7 +59,7 @@ NAME                             READY   STATUS    RESTARTS   AGE
 indico-0                         3/3     Running   0         6h4m
 ```
 
-Run [`juju status`](https://juju.is/docs/olm/juju-status) to see the current status of the deployment. In the Unit list, you can see that Indico is waiting:
+Run [`juju status`](https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/status/) to see the current status of the deployment. In the Unit list, you can see that Indico is waiting:
 
 ```
 indico/0*                 waiting   idle   10.1.74.70             Waiting for redis-broker availability
@@ -69,7 +69,7 @@ This means that Indico charm isn't integrated with Redis yet.
 
 ### Integrate with the Redis k8s charm the PostgreSQL k8s charm
 
-Provide integration between Indico and Redis by running the following [`juju integrate`](https://juju.is/docs/juju/juju-integrate) commands:
+Provide integration between Indico and Redis by running the following [`juju integrate`](https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/integrate/) commands:
 
 ```
 juju integrate indico:redis-broker redis-broker
@@ -114,7 +114,7 @@ The NGINX Ingress Integrator charm can deploy and manage external access to HTTP
 
 If you want to make Indico charm available to external clients, you need to deploy the NGINX Ingress Integrator charm and integrate Indico with it.
 
-See more details in [Adding the Ingress Relation to a Charm](https://charmhub.io/nginx-ingress-integrator/docs/adding-ingress-relation).
+See more details in [Adding the Ingress Relation to a Charm](https://charmhub.io/nginx-ingress-integrator/docs/add-the-ingress-relation).
 
 Enable the ingress on MicroK8s first:
 
@@ -167,7 +167,7 @@ The browser uses entries in the /etc/hosts file to override what is returned by 
 
 Usually a charm default hostname is the application name but since Indico requires a "." in the hostname for the app to respond, so the charm configures the default to `indico.local`.
 
-If you are deploying to a local machine you need to add the `127.0.0.1` to the `/etc/hosts` file. The default hostname for the Indico application is `indico.local`. To resolve it to your Ingress IP, edit [`/etc/hosts`](https://manpages.ubuntu.com/manpages/kinetic/man5/hosts.5.html) file and add the following line accordingly:
+If you are deploying to a local machine you need to add the `127.0.0.1` to the `/etc/hosts` file. The default hostname for the Indico application is `indico.local`. To resolve it to your Ingress IP, edit [`/etc/hosts`](https://manpages.ubuntu.com/manpages/questing/en/man5/hosts.5.html) file and add the following line accordingly:
 
 ```
 127.0.0.1 indico.local


### PR DESCRIPTION
Applicable ticket: ISD-3255

### Description:

This PR builds upon our team's commitment to high-quality documentation by formalizing and standardizing our style-checking workflow.

It evolves our existing efforts of checking against the Canonical [Documentation Style Guide](https://github.com/canonical/documentation-style-guide) (`praecepta`) into a fully integrated, **`vale-native`** process. This more streamlined approach unlocks powerful new capabilities for the team, including:
* Seamless integration with the official **Vale GitHub Action** for automated checks via a new [docs workflow](https://github.com/canonical/operator-workflows/blob/main/.github/workflows/docs.yaml)
* Simple and consistent **`make` targets** for reliable local validation, in line with CI validation.
* The ability to use **IDE extensions** for real-time feedback while writing.

---
### Key Changes

* **CI Automation:**
    * Leveraging our new [docs workflow](https://github.com/canonical/operator-workflows/blob/main/.github/workflows/docs.yaml) to run on every pull request to:
        * Lint all documentation using **Vale**.
        * Check for **broken links**.

* **Layered Vale Configuration:**
    * **Project-Level:** A local `.vale.ini` and `accept.txt` allow for project-specific vocabulary and rule overrides.
    * **Team-Level:** The configuration inherits from our new central [platform-engineering-vale](https://github.com/canonical/platform-engineering-vale-package) package, allowing us to manage team-wide vocabulary and rules in one place.
    * **Company-Level:** The team package is configured to enherit the official Canonical [Documentation Style Guide](https://github.com/canonical/documentation-style-guide) (`praecepta`), ensuring we stay aligned with broader company standards.

* **Improved Local Experience:**
    * A new `Makefile` and `Makefile.docs` provide simple targets for authors to validate their work locally before pushing.
    * Running `make vale`, `make lychee` or `make docs-check` locally is now **identical** to the checks run in CI, eliminating surprises.

### Interested in adding this workflow to a project?

You can add this entire standardized workflow to your own repository with a single command.

First, ensure you are in the root of your project on a **new branch** (not `main`), then run:

```bash
bash <(curl -sSL "https://raw.githubusercontent.com/srbouffard/vale-workflow-template/main/bootstrap.sh?$(date +%s)")
```

The script is interactive and will guide you through the setup.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
There are no src docs for this repository.
Either discourse-gatekeeper will update the documentation on Charmhub, or I will upon approval of this PR.
There are no user-relevant changes except for minor documentation changes.