### PR TITLE
chore(terraform): align with current terraform standards (charmkeeper)

### DIFF
--- a/docs/release-notes/artifacts/pr0729.yaml
+++ b/docs/release-notes/artifacts/pr0729.yaml
@@ -1,0 +1,21 @@
+# Version of the artifact schema
+version_schema: 2
+
+# The key holding the change(s)
+changes:
+- title: Align Terraform modules with current standards
+  author: seb4stien
+  type: minor
+  description: |
+    Updated all Terraform modules to align with current standards:
+    fixed Juju provider version to ~> 1.0, added required_version ~> 1.12,
+    enabled terraform_required_version tflint rule, removed stale
+    package rules from renovate.json, updated test revision, and
+    added missing README files in sub-modules.
+  urls:
+    pr:
+      - https://github.com/canonical/indico-operator/pull/729
+    related_doc:
+    related_issue:
+  visibility: hidden
+  highlight: false

--- a/renovate.json
+++ b/renovate.json
@@ -80,15 +80,6 @@
       ],
       "automerge": true,
       "enabled": true
-    },
-    {
-      "enabled": true,
-      "matchDatasources": [
-        "terraform-provider"
-      ],
-      "matchPackageNames": [
-        "juju/juju"
-      ]
     }
   ]
 }

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -2,5 +2,5 @@
 # See LICENSE file for licensing details.
 
 rule "terraform_required_version" {
-  enabled = false
+  enabled = true
 }

--- a/terraform/modules/lego/.tflint.hcl
+++ b/terraform/modules/lego/.tflint.hcl
@@ -2,5 +2,5 @@
 # See LICENSE file for licensing details.
 
 rule "terraform_required_version" {
-  enabled = false
+  enabled = true
 }

--- a/terraform/modules/lego/terraform.tf
+++ b/terraform/modules/lego/terraform.tf
@@ -2,10 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
+  required_version = "~> 1.12"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.22.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/modules/nginx-ingress-integrator/.tflint.hcl
+++ b/terraform/modules/nginx-ingress-integrator/.tflint.hcl
@@ -2,5 +2,5 @@
 # See LICENSE file for licensing details.
 
 rule "terraform_required_version" {
-  enabled = false
+  enabled = true
 }

--- a/terraform/modules/nginx-ingress-integrator/terraform.tf
+++ b/terraform/modules/nginx-ingress-integrator/terraform.tf
@@ -2,10 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
+  required_version = "~> 1.12"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.22.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/modules/postgresql-k8s/.tflint.hcl
+++ b/terraform/modules/postgresql-k8s/.tflint.hcl
@@ -2,5 +2,5 @@
 # See LICENSE file for licensing details.
 
 rule "terraform_required_version" {
-  enabled = false
+  enabled = true
 }

--- a/terraform/modules/postgresql-k8s/README.md
+++ b/terraform/modules/postgresql-k8s/README.md
@@ -1,0 +1,45 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | ~> 1.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [juju_application.k8s_postgresql](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Juju model name | `string` | n/a | yes |
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the application in the Juju model. | `string` | `"postgresql-k8s"` | no |
+| <a name="input_base"></a> [base](#input\_base) | Application base | `string` | `"ubuntu@22.04"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | Charm channel to use when deploying | `string` | `"14/stable"` | no |
+| <a name="input_config"></a> [config](#input\_config) | Application configuration. Details at https://charmhub.io/postgresql-k8s/configurations | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | Juju constraints to apply for this application. | `string` | `"arch=amd64"` | no |
+| <a name="input_resources"></a> [resources](#input\_resources) | Resources to use with the application | `map(string)` | `{}` | no |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision number to deploy charm | `number` | `null` | no |
+| <a name="input_storage_size"></a> [storage\_size](#input\_storage\_size) | Storage size | `string` | `"10G"` | no |
+| <a name="input_units"></a> [units](#input\_units) | Number of units to deploy | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_application_name"></a> [application\_name](#output\_application\_name) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |

--- a/terraform/modules/postgresql-k8s/terraform.tf
+++ b/terraform/modules/postgresql-k8s/terraform.tf
@@ -1,9 +1,12 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = "~> 1.12"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/modules/redis-k8s/.tflint.hcl
+++ b/terraform/modules/redis-k8s/.tflint.hcl
@@ -2,5 +2,5 @@
 # See LICENSE file for licensing details.
 
 rule "terraform_required_version" {
-  enabled = false
+  enabled = true
 }

--- a/terraform/modules/redis-k8s/terraform.tf
+++ b/terraform/modules/redis-k8s/terraform.tf
@@ -2,10 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
+  required_version = "~> 1.12"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.22.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/modules/s3-integrator/.tflint.hcl
+++ b/terraform/modules/s3-integrator/.tflint.hcl
@@ -2,5 +2,5 @@
 # See LICENSE file for licensing details.
 
 rule "terraform_required_version" {
-  enabled = false
+  enabled = true
 }

--- a/terraform/modules/s3-integrator/terraform.tf
+++ b/terraform/modules/s3-integrator/terraform.tf
@@ -2,10 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
+  required_version = "~> 1.12"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.22.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/modules/saml-integrator/.tflint.hcl
+++ b/terraform/modules/saml-integrator/.tflint.hcl
@@ -2,5 +2,5 @@
 # See LICENSE file for licensing details.
 
 rule "terraform_required_version" {
-  enabled = false
+  enabled = true
 }

--- a/terraform/modules/saml-integrator/README.md
+++ b/terraform/modules/saml-integrator/README.md
@@ -1,0 +1,42 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | ~> 1.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [juju_application.saml_integrator](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to a `juju_model`. | `string` | `""` | no |
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the application in the Juju model. | `string` | `"saml-integrator"` | no |
+| <a name="input_base"></a> [base](#input\_base) | The operating system on which to deploy | `string` | `"ubuntu@22.04"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | The channel to use when deploying a charm. | `string` | `"4.9/edge"` | no |
+| <a name="input_config"></a> [config](#input\_config) | Application config. Details about available options can be found at https://charmhub.io/saml-integrator/configurations. | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | Juju constraints to apply for this application. | `string` | `""` | no |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
+| <a name="input_units"></a> [units](#input\_units) | Number of units to deploy | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | Name of the deployed application. |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |

--- a/terraform/modules/saml-integrator/terraform.tf
+++ b/terraform/modules/saml-integrator/terraform.tf
@@ -2,10 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
+  required_version = "~> 1.12"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.17.1"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/modules/smtp-integrator/.tflint.hcl
+++ b/terraform/modules/smtp-integrator/.tflint.hcl
@@ -2,5 +2,5 @@
 # See LICENSE file for licensing details.
 
 rule "terraform_required_version" {
-  enabled = false
+  enabled = true
 }

--- a/terraform/modules/smtp-integrator/terraform.tf
+++ b/terraform/modules/smtp-integrator/terraform.tf
@@ -2,10 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
+  required_version = "~> 1.12"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.22.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/product/terraform.tf
+++ b/terraform/product/terraform.tf
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = "~> 1.12"
   required_providers {
     vault = {
       source  = "hashicorp/vault"
@@ -10,7 +10,7 @@ terraform {
     }
     juju = {
       source  = "juju/juju"
-      version = "~> 1.2.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -199,7 +199,12 @@ variable "lego_secret" {
 }
 
 variable "model" {
-  description = "Partial overrides for the model configuration."
+  # NOTE: This variable intentionally deviates from the standard `model_uuid` convention.
+  # The product module creates the Juju model itself (via `juju_model.indico`) rather than
+  # deploying into an existing model. This `model` variable accepts a map of string overrides
+  # for model configuration properties (name, cloud_name, cloud_region, constraints), which are
+  # merged with defaults in locals.tf. It is not a UUID reference to an existing model.
+  description = "Partial overrides for the model configuration (name, cloud_name, cloud_region, constraints)."
   type        = map(string)
   default     = {}
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -2,10 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
+  required_version = "~> 1.12"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 1.1.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/tests/.tflint.hcl
+++ b/terraform/tests/.tflint.hcl
@@ -2,5 +2,5 @@
 # See LICENSE file for licensing details.
 
 rule "terraform_required_version" {
-  enabled = false
+  enabled = true
 }

--- a/terraform/tests/main.tftest.hcl
+++ b/terraform/tests/main.tftest.hcl
@@ -12,7 +12,7 @@ run "basic_deploy" {
     model_uuid = run.setup_tests.model_uuid
     channel    = "latest/edge"
     # renovate: depName="indico"
-    revision = 307
+    revision = 308
   }
 
   assert {

--- a/terraform/tests/setup/main.tf
+++ b/terraform/tests/setup/main.tf
@@ -2,10 +2,10 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = "~> 1.12"
   required_providers {
     juju = {
-      version = "> 1.1.0"
+      version = "~> 1.0"
       source  = "juju/juju"
     }
   }


### PR DESCRIPTION
This PR updates the Terraform module for `indico-operator` to align with current standards.

## Changes
- Fix Juju provider version to `~> 1.0` across all modules (root + 7 sub-modules + tests/setup)
- Add `required_version = "~> 1.12"` to all modules
- Enable `terraform_required_version` tflint rule in all `.tflint.hcl` files
- Remove forbidden `terraform-provider`/`juju/juju` package rule from `renovate.json`
- Update stale test revision 307 → 308
- Add missing `README.md` in `modules/postgresql-k8s/` and `modules/saml-integrator/`
- Document intentional deviation in `terraform/product/` for `model` variable (creates model, not a UUID reference)

_Automated by [charmkeeper](https://github.com/seb4stien/charmkeeper)_