### PR TITLE
docs: Add or update landing pages

### DIFF
--- a/.github/workflows/check_release_notes_artifact.yaml
+++ b/.github/workflows/check_release_notes_artifact.yaml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   check-change-artifacts:
-    uses: canonical/release-notes-automation/.github/workflows/pr-compliance.yml@main
+    permissions:
+      contents: write
+    uses: canonical/release-notes-automation/.github/workflows/pr-compliance-autofill.yml@main
     secrets: inherit
     with:
       change-artifact-dir: docs/release-notes/artifacts

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -4,47 +4,36 @@ Task-oriented procedures for configuring integrations, managing network access,
 customizing Indico's appearance and functionality, and handling operational tasks
 like redeployment and development contributions.
 
-## Integration
-<!--
-Themes: external service integration, authentication, storage, email
-Justification: shared operational concern — connecting Indico to external services via Juju relations
-User journey context: configuration, integration phase
-Juju ecosystem scope: cross-charm (relation integration with S3, SAML, SMTP integrators)
--->
+## Customization
+
+Once you’ve deployed the charm, you can customize your Indico deployment
+with plugins and themes to suit your specific use case.
+
+- [Install plugins](install-plugins.md)
+- [Customize theme](customize-theme.md)
+
+## Configuration
+
+With a customized Indico deployment, you can use built-in integrations
+to configure the charm based on your requirements around authentication, storage, and email.
 
 - [Configure S3](configure-s3.md)
 - [Configure SAML](configure-saml.md)
 - [Configure SMTP](configure-smtp.md)
 
 ## Networking and access
-<!--
-Themes: proxy configuration, external hostname, ingress
-Justification: shared concern — network-level configuration for external connectivity
-User journey context: configuration, initial setup
-Juju ecosystem scope: model-level (proxy), cross-charm (ingress integration)
--->
+
+The Indico charm comes with built-in configurations to connect your
+deployment to the outside world safely and according to your needs.
 
 - [Configure a proxy](configure-a-proxy.md)
 - [Configure the external hostname](configure-the-external-hostname.md)
 
-## Customization
-<!--
-Themes: plugin installation, theme modification, extensibility
-Justification: shared concern — extending and personalizing Indico's default behavior
-User journey context: post-deployment, configuration
-Juju ecosystem scope: charm-specific (configuration options, actions)
--->
-
-- [Install plugins](install-plugins.md)
-- [Customize theme](customize-theme.md)
-
 ## Maintenance and development
-<!--
-Themes: redeployment/migration, development contribution, charm lifecycle
-Justification: shared operational concern — sustaining and evolving the charm beyond initial deployment
-User journey context: maintenance, development
-Juju ecosystem scope: charm-specific (redeployment), model-level (migration), cross-charm (testing integrations)
--->
+
+Now that your deployment is fully configured and customized, now you can
+focus on sustaining and evolving the Indico charm beyond your initial
+deployment, including contributing missing features or bug fixes.
 
 - [Redeploy](redeploy.md)
 - [Contribute](contribute.md)

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,32 +1,50 @@
 # How-to guides
 
-The following guides cover key processes and common tasks for managing
-and using the Indico charm.
+Task-oriented procedures for configuring integrations, managing network access,
+customizing Indico's appearance and functionality, and handling operational tasks
+like redeployment and development contributions.
 
+## Integration
+<!--
+Themes: external service integration, authentication, storage, email
+Justification: shared operational concern — connecting Indico to external services via Juju relations
+User journey context: configuration, integration phase
+Juju ecosystem scope: cross-charm (relation integration with S3, SAML, SMTP integrators)
+-->
 
-## Basic operations
-* [Configure a proxy]
-* [Configure S3]
-* [Configure SAML]
-* [Configure SMTP]
-* [Configure the external hostname]
-* [Install plugins]
-* [Customize theme]
+- [Configure S3](configure-s3.md)
+- [Configure SAML](configure-saml.md)
+- [Configure SMTP](configure-smtp.md)
 
-## Upgrade and redeployment 
-* [Redeploy]
+## Networking and access
+<!--
+Themes: proxy configuration, external hostname, ingress
+Justification: shared concern — network-level configuration for external connectivity
+User journey context: configuration, initial setup
+Juju ecosystem scope: model-level (proxy), cross-charm (ingress integration)
+-->
 
-## Development
-* [Contribute]
+- [Configure a proxy](configure-a-proxy.md)
+- [Configure the external hostname](configure-the-external-hostname.md)
 
-<!--Links-->
+## Customization
+<!--
+Themes: plugin installation, theme modification, extensibility
+Justification: shared concern — extending and personalizing Indico's default behavior
+User journey context: post-deployment, configuration
+Juju ecosystem scope: charm-specific (configuration options, actions)
+-->
 
-[Configure a proxy]: configure-a-proxy.md
-[Configure S3]: configure-s3.md
-[Configure SAML]: configure-saml.md
-[Configure SMTP]: configure-smtp.md
-[Configure the external hostname]: configure-the-external-hostname.md
-[Install plugins]: install-plugins.md
-[Customize theme]: customize-theme.md
-[Redeploy]: redeploy.md
-[Contribute]: contribute.md
+- [Install plugins](install-plugins.md)
+- [Customize theme](customize-theme.md)
+
+## Maintenance and development
+<!--
+Themes: redeployment/migration, development contribution, charm lifecycle
+Justification: shared operational concern — sustaining and evolving the charm beyond initial deployment
+User journey context: maintenance, development
+Juju ecosystem scope: charm-specific (redeployment), model-level (migration), cross-charm (testing integrations)
+-->
+
+- [Redeploy](redeploy.md)
+- [Contribute](contribute.md)

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -31,7 +31,7 @@ deployment to the outside world safely and according to your needs.
 
 ## Maintenance and development
 
-Now that your deployment is fully configured and customized, now you can
+Now that your deployment is fully configured and customized, you can
 focus on sustaining and evolving the Indico charm beyond your initial
 deployment, including contributing missing features or bug fixes.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ This charm will make operating Indico simple and straightforward for DevOps or S
 | | |
 |--|--|
 |  [Tutorials](https://charmhub.io/indico/docs/tutorial)</br>  Get started - a hands-on introduction to using the Charmed Indico operator for new users </br> |  [How-to guides](https://charmhub.io/indico/docs/how-to-configure-a-proxy) </br> Step-by-step guides covering key operations and common tasks |
-| [Reference](https://charmhub.io/indico/docs/reference-actions) </br> Technical information - specifications, APIs, architecture | [Explanation]() </br> Concepts - discussion and clarification of key topics  |
+| [Reference](https://charmhub.io/indico/docs/reference-actions) </br> Technical information - specifications, APIs, architecture | |
 
 ## Contributing to this documentation
 
@@ -39,7 +39,7 @@ Thinking about using the Indico Operator for your next project? [Get in touch](h
 # Contents
 
 1. [Tutorial](tutorial.md)
-1. [How to](how-to)
+1. [How to](how-to/index.md)
   1. [Configure a proxy](how-to/configure-a-proxy.md)
   1. [Configure S3](how-to/configure-s3.md)
   1. [Configure SAML](how-to/configure-saml.md)
@@ -49,7 +49,7 @@ Thinking about using the Indico Operator for your next project? [Get in touch](h
   1. [Customize theme](how-to/customize-theme.md)
   1. [Redeploy](how-to/redeploy.md)
   1. [Contribute](how-to/contribute.md)
-1. [Reference](reference)
+1. [Reference](reference/index.md)
   1. [Actions](reference/actions.md)
   1. [Charm architecture](reference/charm-architecture.md)
   1. [Configurations](reference/configurations.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -5,35 +5,27 @@ integration interfaces, extensibility mechanisms, and runtime behavior within a
 Juju-managed Kubernetes environment.
 
 ## Charm configuration and operations
-<!--
-Themes: charm lifecycle, configuration options, operational actions
-Justification: core charm machinery — configuration, actions, and architectural internals
-User journey context: all stages (lookup-driven)
-Juju ecosystem scope: charm-specific (configuration, actions), cross-charm (relation events)
--->
+
+Your operational decisions depend on the charm’s configuration options,
+its available actions, and the underlying design decisions behind the
+charm's architecture.
 
 - [Actions](actions.md)
 - [Configurations](configurations.md)
 - [Charm architecture](charm-architecture.md)
 
 ## Extensibility
-<!--
-Themes: plugin architecture, theme customization, external resources
-Justification: shared concern — extending Indico functionality beyond defaults
-User journey context: configuration, post-deployment customization
-Juju ecosystem scope: charm-specific (configuration options)
--->
+
+Your Indico deployment can be customized with plugins and
+themes to match your specific needs and use case.
 
 - [Plugins](plugins.md)
 - [Theme customization](theme-customization.md)
 
 ## Networking and integrations
-<!--
-Themes: relation interfaces, external network access, ingress
-Justification: shared concern — connectivity between charm and external systems
-User journey context: integration, scaling, troubleshooting
-Juju ecosystem scope: cross-charm (relation endpoints), model-level (ingress/networking)
--->
+
+Expanding Indico's reach in Juju depends on the charm’s relation interfaces,
+and your deployment’s reach to the outside world depends on the mechanisms for external access.
 
 - [Integrations](integrations.md)
 - [External access](external-access.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,39 @@
+# Reference
+
+Technical specifications and descriptions for the Indico charm's configuration surfaces,
+integration interfaces, extensibility mechanisms, and runtime behavior within a
+Juju-managed Kubernetes environment.
+
+## Charm configuration and operations
+<!--
+Themes: charm lifecycle, configuration options, operational actions
+Justification: core charm machinery — configuration, actions, and architectural internals
+User journey context: all stages (lookup-driven)
+Juju ecosystem scope: charm-specific (configuration, actions), cross-charm (relation events)
+-->
+
+- [Actions](actions.md)
+- [Configurations](configurations.md)
+- [Charm architecture](charm-architecture.md)
+
+## Extensibility
+<!--
+Themes: plugin architecture, theme customization, external resources
+Justification: shared concern — extending Indico functionality beyond defaults
+User journey context: configuration, post-deployment customization
+Juju ecosystem scope: charm-specific (configuration options)
+-->
+
+- [Plugins](plugins.md)
+- [Theme customization](theme-customization.md)
+
+## Networking and integrations
+<!--
+Themes: relation interfaces, external network access, ingress
+Justification: shared concern — connectivity between charm and external systems
+User journey context: integration, scaling, troubleshooting
+Juju ecosystem scope: cross-charm (relation endpoints), model-level (ingress/networking)
+-->
+
+- [Integrations](integrations.md)
+- [External access](external-access.md)

--- a/docs/release-notes/artifacts/2604_landing_pages.yaml
+++ b/docs/release-notes/artifacts/2604_landing_pages.yaml
@@ -1,0 +1,20 @@
+# Version of the artifact schema
+version_schema: 2
+
+# The key holding the change(s)
+changes:
+- title: Updated landing pages
+  author: erinecon
+  type: minor
+  description: |
+    Now the landing pages serve as useful navigational tools
+    for users, categorizing content by related themes or domains,
+    and providing explanations for each section.
+  urls:
+    pr: 
+      - 
+    related_doc: docs/how-to/index.md, docs/reference/index.md
+    related_issue: 
+  visibility: hidden
+  highlight: false
+

--- a/docs/release-notes/artifacts/2604_landing_pages.yaml
+++ b/docs/release-notes/artifacts/2604_landing_pages.yaml
@@ -1,20 +1,18 @@
 # Version of the artifact schema
 version_schema: 2
-
 # The key holding the change(s)
 changes:
-- title: Updated landing pages
-  author: erinecon
-  type: minor
-  description: |
-    Now the landing pages serve as useful navigational tools
-    for users, categorizing content by related themes or domains,
-    and providing explanations for each section.
-  urls:
-    pr: 
-      - 
-    related_doc: docs/how-to/index.md, docs/reference/index.md
-    related_issue: 
-  visibility: hidden
-  highlight: false
-
+  - title: Updated landing pages
+    author: erinecon
+    type: minor
+    description: |
+      Now the landing pages serve as useful navigational tools
+      for users, categorizing content by related themes or domains,
+      and providing explanations for each section.
+    urls:
+      pr:
+        - https://github.com/canonical/indico-operator/pull/761
+      related_doc: docs/how-to/index.md, docs/reference/index.md
+      related_issue:
+    visibility: hidden
+    highlight: false


### PR DESCRIPTION
Applicable ticket: ISD-5229

### Overview

Updated `docs/how-to/index.md` and added `docs/reference/index.md`.

I also updated the PR compliance workflow to use the new "autofill" functionality; users no longer need to populate the `pr` key of the YAML artifacts, a bot will identify and push a commit to do this automatically.

I used Copilot to prepare this PR.

### Rationale

Now the landing pages align closer to the standard model. They organize the content in terms of themes and domains, and each section contains an explanation for what users can expect to find in the pages.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [X] A [change artifact](https://github.com/canonical/indico-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
I'll update the Charmhub documentation once this PR is approved.