### PR TITLE
test: adopt -Werror in unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,20 @@ pythonpath = [
   "lib",
   "src"
 ]
+filterwarnings = [
+  "error",
+  # Harness is intentional here: the unit_harness/ suite stays on Harness.
+  "ignore:Harness is deprecated:PendingDeprecationWarning",
+  # JujuVersion.from_environ deprecation from vendored data_platform_libs;
+  # upstream canonical/data-platform-libs.
+  "ignore:JujuVersion.from_environ\\(\\) is deprecated:DeprecationWarning:charms.data_platform_libs.v0.data_interfaces",
+  # TEMPORARY: Harness tempdir leak (operator#2506/#2507). Drop on the next
+  # ops 2.23 release that backports the fix, or when this charm moves to
+  # ops >= 3.8 (where the fix already shipped).
+  "ignore:Implicitly cleaning up:ResourceWarning",
+  # TEMPORARY: scenario.Context leaks file handles for the charm metadata
+  # files (metadata.yaml, charmcraft.yaml, actions.yaml, config.yaml) on
+  # teardown (operator#2506/#2507). Drop on the next ops 2.23 release that
+  # backports the fix, or when this charm moves to ops >= 3.8.
+  "ignore:unclosed file.*\\.yaml:ResourceWarning",
+]

--- a/src/charm.py
+++ b/src/charm.py
@@ -23,7 +23,6 @@ from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.redis_k8s.v0.redis import RedisRelationCharmEvents, RedisRequires
 from ops.charm import ActionEvent, CharmBase, HookEvent, PebbleReadyEvent, RelationDepartedEvent
-from ops.jujuversion import JujuVersion
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, Container, MaintenanceStatus, WaitingStatus
 from ops.pebble import ExecError
@@ -890,10 +889,9 @@ class IndicoOperatorCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         Returns:
             If secrets are supported or not.
         """
-        juju_version = JujuVersion.from_environ()
         # Because we're only using secrets in a peer relation we don't need to
         # check if the other end of a relation also supports secrets...
-        return juju_version.has_secrets
+        return self.model.juju_version.has_secrets
 
     def _add_admin_action(self, event: ActionEvent) -> None:
         """Add a new user to Indico.

--- a/tests/unit/test_on_leader_elected.py
+++ b/tests/unit/test_on_leader_elected.py
@@ -3,7 +3,7 @@
 
 """Indico charm unit tests."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import ops
 from ops import testing
@@ -11,7 +11,7 @@ from ops import testing
 from charm import IndicoOperatorCharm
 
 
-@patch.object(ops.JujuVersion, "from_environ")
+@patch.object(ops.model.Model, "juju_version", new_callable=PropertyMock)
 def test_on_leader_elected_when_secrets_supported(mock_juju_env, base_state: dict):
     """
     arrange: charm created, leader selected and secrets supported

--- a/tests/unit_harness/test_core.py
+++ b/tests/unit_harness/test_core.py
@@ -6,7 +6,7 @@
 # pylint:disable=duplicate-code,protected-access
 from ast import literal_eval
 from secrets import token_hex
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import ops
 import pytest
@@ -184,7 +184,7 @@ class TestCore(TestBase):  # pylint: disable=too-many-public-methods
         self.harness.container_pebble_ready("indico-nginx")
         self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
 
-    @patch.object(ops.JujuVersion, "from_environ")
+    @patch.object(ops.model.Model, "juju_version", new_callable=PropertyMock)
     @patch.object(ops.Container, "exec")
     def test_indico_pebble_ready_when_secrets_not_enabled(self, mock_exec, mock_juju_env):
         """
@@ -229,7 +229,7 @@ class TestCore(TestBase):  # pylint: disable=too-many-public-methods
         self.assertTrue(service.is_running())
         self.assertEqual(self.harness.model.unit.status, ops.WaitingStatus("Waiting for pebble"))
 
-    @patch.object(ops.JujuVersion, "from_environ")
+    @patch.object(ops.model.Model, "juju_version", new_callable=PropertyMock)
     @patch.object(ops.Container, "exec")
     def test_indico_pebble_ready_when_secrets_enabled(self, mock_exec, mock_juju_env):
         """
@@ -542,7 +542,7 @@ class TestCore(TestBase):  # pylint: disable=too-many-public-methods
         identity_providers = literal_eval(updated_plan_env["INDICO_IDENTITY_PROVIDERS"])
         self.assertEqual("saml_groups", identity_providers["ubuntu"]["type"])
 
-    @patch.object(ops.JujuVersion, "from_environ")
+    @patch.object(ops.model.Model, "juju_version", new_callable=PropertyMock)
     def test_on_leader_elected_when_secrets_not_supported(self, mock_juju_env):
         """
         arrange: charm created and secrets not supported
@@ -563,7 +563,7 @@ class TestCore(TestBase):  # pylint: disable=too-many-public-methods
             self.harness.get_relation_data(rel_id, self.harness.charm.app.name).get("secret-key"),
         )
 
-    @patch.object(ops.JujuVersion, "from_environ")
+    @patch.object(ops.model.Model, "juju_version", new_callable=PropertyMock)
     def test_on_leader_elected_when_secrets_supported(self, mock_juju_env):
         """
         arrange: charm created and secrets supported
@@ -583,7 +583,7 @@ class TestCore(TestBase):  # pylint: disable=too-many-public-methods
             self.harness.get_relation_data(rel_id, self.harness.charm.app.name).get("secret-id"),
         )
 
-    @patch.object(ops.JujuVersion, "from_environ")
+    @patch.object(ops.model.Model, "juju_version", new_callable=PropertyMock)
     def test_on_leader_elected_sets_celery_unit(self, mock_juju_env):
         """
         arrange: given a charm with an empty peer relation
@@ -598,7 +598,7 @@ class TestCore(TestBase):  # pylint: disable=too-many-public-methods
         )
         self.assertEqual(celery_unit, self.harness.charm.unit.name)
 
-    @patch.object(ops.JujuVersion, "from_environ")
+    @patch.object(ops.model.Model, "juju_version", new_callable=PropertyMock)
     def test_on_leader_elected_not_sets_celery_unit_when_existing(self, mock_juju_env):
         """
         arrange: given a charm with a peer relation with celery-unit in the databag
@@ -615,7 +615,7 @@ class TestCore(TestBase):  # pylint: disable=too-many-public-methods
         )
         self.assertEqual(celery_unit, "example")
 
-    @patch.object(ops.JujuVersion, "from_environ")
+    @patch.object(ops.model.Model, "juju_version", new_callable=PropertyMock)
     def test_on_peer_relation_departed_no_celery_unit_relation_data_unchanged(self, mock_juju_env):
         """
         arrange: given a charm with two units and a peer relation with celery-unit in the databag
@@ -635,7 +635,7 @@ class TestCore(TestBase):  # pylint: disable=too-many-public-methods
         self.harness.remove_relation_unit(rel_id, "indico/1")
         self.assertEqual(celery_unit, "example")
 
-    @patch.object(ops.JujuVersion, "from_environ")
+    @patch.object(ops.model.Model, "juju_version", new_callable=PropertyMock)
     def test_on_peer_relation_departed_celery_unit_relation_data_changed(self, mock_juju_env):
         """
         arrange: given a charm with two units and a peer relation with celery-unit in the databag
@@ -656,7 +656,7 @@ class TestCore(TestBase):  # pylint: disable=too-many-public-methods
         )
         self.assertEqual(celery_unit, "indico/0")
 
-    @patch.object(ops.JujuVersion, "from_environ")
+    @patch.object(ops.model.Model, "juju_version", new_callable=PropertyMock)
     def test_on_peer_relation_departed_celery_leder_unit_relation_data_changed(
         self, mock_juju_env
     ):
@@ -679,7 +679,7 @@ class TestCore(TestBase):  # pylint: disable=too-many-public-methods
         )
         self.assertIsNone(celery_unit)
 
-    @patch.object(ops.JujuVersion, "from_environ")
+    @patch.object(ops.model.Model, "juju_version", new_callable=PropertyMock)
     @patch.object(ops.Container, "exec")
     def test_indico_pebble_ready_when_leader_includes_celery(self, mock_exec, mock_juju_env):
         """
@@ -698,7 +698,7 @@ class TestCore(TestBase):  # pylint: disable=too-many-public-methods
         assert "indico" in updated_plan["services"]
         assert "celery" in updated_plan["services"]
 
-    @patch.object(ops.JujuVersion, "from_environ")
+    @patch.object(ops.model.Model, "juju_version", new_callable=PropertyMock)
     @patch.object(ops.Container, "exec")
     def test_indico_pebble_ready_when_not_leader_doesnt_include_celery(
         self, mock_exec, mock_juju_env

--- a/tox.ini
+++ b/tox.ini
@@ -165,7 +165,8 @@ deps =
     pytest-operator
     websockets<14.0 # https://github.com/juju/python-libjuju/issues/1184
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s \
+        --override-ini=filterwarnings= {posargs}
 
 [testenv:src-docs]
 allowlist_externals=sh


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Promote warnings to errors in the unit suite, and clear the one production deprecation it surfaces so the suite is green under it as-pinned.

- `src/charm.py`: `_has_secrets()` switches from the deprecated `JujuVersion.from_environ()` to `self.model.juju_version.has_secrets`.
- `pyproject.toml`: adopt `-Werror`, with four narrow, message-anchored, individually justified ignores:
  - `Harness is deprecated`.
  - `JujuVersion.from_environ()` from the vendored `data_platform_libs` lib: module-scoped, upstream `canonical/data-platform-libs`.
  - `Implicitly cleaning up <TemporaryDirectory>` Harness teardown leak: temporary, drop on the next `ops` 2.23 release that backports the fix or when this charm moves to `ops >= 3.8`.
  - `unclosed file …yaml` `scenario.Context` teardown leak on the charm metadata files, same temporary situation.

### Rationale

Without `-Werror` the suite was carrying 97 warnings, including a real production deprecation in `_has_secrets()`. Flipping turns those into a CI signal so future deprecations and resource leaks fail the suite rather than piling up quietly. Context: [discourse post](https://discourse.charmhub.io/t/catch-problems-before-they-bite-turn-on-werror-in-your-charms-unit-tests/20618?u=tony-meyer).

### Juju Events Changes

None.

### Module Changes

`_has_secrets()` reads the juju version from `self.model.juju_version` instead of calling the deprecated `JujuVersion.from_environ()`; same observable behaviour.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] ~The documentation for charmhub is updated~
- [ ] A [change artifact](https://github.com/canonical/indico-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. **I cannot add tags.**
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`). **I cannot add tags.**
- [ ] ~The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)~