### PR TITLE
fix: publish to edge resource mapping

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -10,3 +10,5 @@ jobs:
   publish-to-edge:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit
+    with:
+      resource-mapping: '{"indico": "flask-app-image"}'

--- a/docs/release-notes/artifacts/pr0774.yaml
+++ b/docs/release-notes/artifacts/pr0774.yaml
@@ -1,0 +1,15 @@
+# --- Release notes artifact ----
+
+schema_version: 1
+changes:
+  - title: Add a fix to publish edge workflow to include the flask-app-image resource mapping
+    author: DeeKay3
+    type: minor
+    description: "Add a fix to the publish edge workflow to include the flask-app-image resource mapping, ensuring that the indico charm is correctly published with its associated resources."
+    urls:
+      pr:
+        - https://github.com/canonical/indico-operator/pull/774
+      related_doc:
+      related_issue:
+    visibility: internal
+    highlight: false


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Fix for publishing workflow

### Rationale

Without it, we can't publish charms

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] A [change artifact](https://github.com/canonical/indico-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->