### PR TITLE
fix(ci): grant contents/packages write to publish-to-edge

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   publish-to-edge:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    permissions:
+      contents: write
+      packages: write
     secrets: inherit
     with:
       resource-mapping: '{"indico": "flask-app-image"}'

--- a/docs/release-notes/artifacts/pr0781.yaml
+++ b/docs/release-notes/artifacts/pr0781.yaml
@@ -1,0 +1,15 @@
+# --- Release notes artifact ----
+
+schema_version: 1
+changes:
+  - title: Grant contents and packages write permissions to the publish edge workflow
+    author: DeeKay3
+    type: bugfix
+    description: "Grant contents and packages write permissions to the publish-to-edge job so the reusable publish workflow can create the git tag and release after uploading the charm. Without these permissions the tag and release step failed with 'Resource not accessible by integration' even though the charm revision was published successfully."
+    urls:
+      pr:
+        - https://github.com/canonical/indico-operator/pull/781
+      related_doc:
+      related_issue:
+    visibility: internal
+    highlight: false


### PR DESCRIPTION
The publish-to-edge job calls the reusable publish_charm workflow, which uses charming-actions/upload-charm to create a git tag and release after publishing the charm. With no permissions block, the calling job inherited the repository's restricted default GITHUB_TOKEN, so the tag/release step failed with 'Resource not accessible by integration' even though the charm revision was uploaded and released successfully.

Grant contents: write (tag/release creation) and packages: write (rock image access from ghcr), matching the convention used in integration_test.yaml.

Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [ ] A [change artifact](https://github.com/canonical/indico-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->