### PR TITLE
docs: update Redis deployment guidance

### DIFF
--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -22,13 +22,11 @@ _Interface_: redis
 _Supported charms_: [redis-k8s](https://charmhub.io/redis-k8s)
 
 Redis integration is a required relation for the Indico charm to supply caching capabilities and
-a message broker to interface with Celery. As such, two instances are needed, `redis-cache` and 
-`redis-broker`.
+a message broker to interface with Celery. A single Redis application provides both functions.
 
-Example `redis` integrate commands: 
+Example `redis` integrate command:
 ```
-juju integrate redis-cache indico 
-juju integrate redis-broker indico
+juju integrate redis-k8s indico
 ```
 
 ### `ingress`

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -39,16 +39,13 @@ juju add-model indico-tutorial
 
 ### Deploy the Indico charm
 
-Since Indico requires connections to PostgreSQL and Redis, you'll deploy them too. For more information, see [Charm Architecture](https://charmhub.io/indico/docs/explanation-charm-architecture).
-
-Redis is deployed twice because one is for the broker and the other for the cache. To do this, the `juju deploy` command accepts an extra argument with the custom application name. See more details in [`juju deploy`](https://canonical.com/juju/docs/juju-cli/3.6/reference/juju-cli/list-of-juju-cli-commands/deploy/).
+Since Indico requires connections to PostgreSQL and Redis, you'll deploy them too. A single Redis application provides both caching and the Celery message broker. For more information, see [Charm Architecture](https://charmhub.io/indico/docs/explanation-charm-architecture).
 
 Deploy the charms:
 
 ```
 juju deploy postgresql-k8s --trust
-juju deploy redis-k8s redis-broker --channel=latest/edge
-juju deploy redis-k8s redis-cache --channel=latest/edge
+juju deploy redis-k8s --channel=latest/edge
 juju deploy indico
 ```
 
@@ -62,18 +59,17 @@ indico-0                         3/3     Running   0         6h4m
 Run [`juju status`](https://canonical.com/juju/docs/juju-cli/3.6/reference/juju-cli/list-of-juju-cli-commands/status/) to see the current status of the deployment. In the Unit list, you can see that Indico is waiting:
 
 ```
-indico/0*                 waiting   idle   10.1.74.70             Waiting for redis-broker availability
+indico/0*                 waiting   idle   10.1.74.70             Waiting for redis availability
 ```
 
 This means that Indico charm isn't integrated with Redis yet.
 
-### Integrate with the Redis k8s charm the PostgreSQL k8s charm
+### Integrate with the Redis K8s charm and PostgreSQL K8s charm
 
-Provide integration between Indico and Redis by running the following [`juju integrate`](https://canonical.com/juju/docs/juju-cli/3.6/reference/juju-cli/list-of-juju-cli-commands/integrate/) commands:
+Provide integration between Indico and Redis by running the following [`juju integrate`](https://canonical.com/juju/docs/juju-cli/3.6/reference/juju-cli/list-of-juju-cli-commands/integrate/) command:
 
 ```
-juju integrate indico:redis-broker redis-broker
-juju integrate indico:redis-cache redis-cache
+juju integrate indico redis-k8s
 ```
 
 Run `juju status` to see that the message has changed:


### PR DESCRIPTION
Applicable spec: N/A — documentation correction tracked by #782

### Overview

Updates the tutorial and integration reference to deploy one `redis-k8s` application and integrate it once with Indico. That matches the charm's single Redis relation and the current integration tests.

Closes #782

### Rationale

The documentation still instructed users to deploy separate `redis-broker` and `redis-cache` applications. Following those steps conflicts with the current charm interface and causes the tutorial to diverge from tested deployment behavior.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [ ] A [change artifact](https://github.com/canonical/indico-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

ISD054 does not apply because there are no charm-code changes. This is a focused correction already categorized as `trivial` and `no-release-note` on #782; maintainers can apply the corresponding PR labels. No changelog or change artifact is needed for the documentation-only correction.

Validation performed:

- Confirmed `charmcraft.yaml` exposes one Redis relation with limit 1
- Confirmed integration tests deploy and integrate one Redis application
- Confirmed the updated pages contain no remaining `redis-broker` or `redis-cache` instructions
- Ran `git diff --check`
